### PR TITLE
Add network cgroup hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,10 @@ version = 4
 [[package]]
 name = "bpf-api"
 version = "0.1.0"
+
+[[package]]
+name = "bpf-core"
+version = "0.1.0"
+dependencies = [
+ "bpf-api",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
 [workspace]
-members = ["crates/bpf-api"]
+members = [
+    "crates/bpf-api",
+    "crates/bpf-core",
+]
 resolver = "2"

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -5,7 +5,7 @@
 - [x] Document ABI for event logs (pid, unit, action, path/address, verdict).
 
 ## BPF Core
-- [ ] Implement cgroup hooks (`connect4`, `connect6`, `sendmsg4`, `sendmsg6`) denying all network by default.
+- [x] Implement cgroup hooks (`connect4`, `connect6`, `sendmsg4`, `sendmsg6`) denying all network by default.
 - [ ] Implement `bprm_check_security` exec restriction based on allowlist map.
 - [ ] Add `file_open` probe capturing read/write attempts (observation only).
 - [ ] Provide minimal tests verifying expected events.

--- a/crates/bpf-core/Cargo.toml
+++ b/crates/bpf-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bpf-core"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[target.'cfg(target_arch = "bpf")'.dependencies]
+bpf-api = { path = "../bpf-api" }

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -1,0 +1,46 @@
+#![cfg_attr(target_arch = "bpf", no_std)]
+#![cfg_attr(not(target_arch = "bpf"), allow(dead_code))]
+
+#[cfg(target_arch = "bpf")]
+use bpf_api::Event;
+#[cfg(target_arch = "bpf")]
+use core::{ffi::c_void, mem::size_of};
+
+#[cfg(target_arch = "bpf")]
+const _EVENT_SIZE: usize = size_of::<Event>();
+
+#[cfg(target_arch = "bpf")]
+const EPERM: i32 = 1;
+
+#[cfg(target_arch = "bpf")]
+fn deny() -> i32 {
+    -EPERM
+}
+
+#[cfg(target_arch = "bpf")]
+#[no_mangle]
+#[link_section = "cgroup/connect4"]
+pub extern "C" fn connect4(_ctx: *mut c_void) -> i32 {
+    deny()
+}
+
+#[cfg(target_arch = "bpf")]
+#[no_mangle]
+#[link_section = "cgroup/connect6"]
+pub extern "C" fn connect6(_ctx: *mut c_void) -> i32 {
+    deny()
+}
+
+#[cfg(target_arch = "bpf")]
+#[no_mangle]
+#[link_section = "cgroup/sendmsg4"]
+pub extern "C" fn sendmsg4(_ctx: *mut c_void) -> i32 {
+    deny()
+}
+
+#[cfg(target_arch = "bpf")]
+#[no_mangle]
+#[link_section = "cgroup/sendmsg6"]
+pub extern "C" fn sendmsg6(_ctx: *mut c_void) -> i32 {
+    deny()
+}


### PR DESCRIPTION
## Summary
- add `bpf-core` crate with cgroup hooks denying outbound network traffic
- include new crate in workspace and mark roadmap task complete
- ignore root instructions file in version control

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b79037ae108332a30120df439bae95