### PR TITLE
Upgrade to Rust 2024 edition

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -29,3 +29,4 @@
 ## Cross-cutting
 - [ ] Provide script or Makefile to run examples under `cargo warden`.
 - [ ] Document setup requirements (BPF LSM, cgroup v2).
+- [x] Update code and docs to Rust 2024 edition.

--- a/SPEC.md
+++ b/SPEC.md
@@ -472,7 +472,7 @@ jobs:
 
 ### C. Code Conventions
 
-* Rust 2021, `clippy` strict, deny warnings
+* Rust 2024, `clippy` strict, deny warnings
 * Format with stable `rustfmt`
 * Public API only in `bpf-api` and `policy-core`; everything else `pub(crate)`
 

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bpf-api"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/crates/bpf-core/Cargo.toml
+++ b/crates/bpf-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bpf-core"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -18,8 +18,8 @@ fn deny() -> i32 {
 }
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "maps/exec_allowlist"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "maps/exec_allowlist")]
 pub static mut EXEC_ALLOWLIST: [bpf_api::ExecAllowEntry; 1] =
     [bpf_api::ExecAllowEntry { path: [0; 256] }];
 
@@ -39,20 +39,20 @@ fn path_matches(a: &[u8; 256], b: &[u8; 256]) -> bool {
 }
 
 #[cfg(any(target_arch = "bpf", test))]
-extern "C" {
+unsafe extern "C" {
     fn bpf_probe_read_user_str(dst: *mut u8, size: u32, src: *const u8) -> i32;
     fn bpf_ringbuf_output(ringbuf: *mut c_void, data: *const c_void, len: u64, flags: u64) -> i64;
     fn bpf_get_current_pid_tgid() -> u64;
 }
 
 #[cfg(any(target_arch = "bpf", test))]
-#[no_mangle]
-#[link_section = "maps/events"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "maps/events")]
 pub static mut EVENTS: [u8; 0] = [];
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "lsm/bprm_check_security"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "lsm/bprm_check_security")]
 pub extern "C" fn bprm_check_security(ctx: *mut c_void) -> i32 {
     let filename_ptr = unsafe { *(ctx as *const *const u8) };
     let mut buf = [0u8; 256];
@@ -70,36 +70,36 @@ pub extern "C" fn bprm_check_security(ctx: *mut c_void) -> i32 {
 }
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "cgroup/connect4"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "cgroup/connect4")]
 pub extern "C" fn connect4(_ctx: *mut c_void) -> i32 {
     deny()
 }
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "cgroup/connect6"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "cgroup/connect6")]
 pub extern "C" fn connect6(_ctx: *mut c_void) -> i32 {
     deny()
 }
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "cgroup/sendmsg4"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "cgroup/sendmsg4")]
 pub extern "C" fn sendmsg4(_ctx: *mut c_void) -> i32 {
     deny()
 }
 
 #[cfg(target_arch = "bpf")]
-#[no_mangle]
-#[link_section = "cgroup/sendmsg6"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "cgroup/sendmsg6")]
 pub extern "C" fn sendmsg6(_ctx: *mut c_void) -> i32 {
     deny()
 }
 
 #[cfg(any(target_arch = "bpf", test))]
-#[no_mangle]
-#[link_section = "lsm/file_open"]
+#[unsafe(no_mangle)]
+#[unsafe(link_section = "lsm/file_open")]
 pub extern "C" fn file_open(_file: *mut c_void, _cred: *mut c_void) -> i32 {
     let event = Event {
         pid: unsafe { (bpf_get_current_pid_tgid() >> 32) as u32 },
@@ -129,7 +129,7 @@ mod tests {
 
     static LAST_EVENT: Mutex<Option<Event>> = Mutex::new(None);
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn bpf_ringbuf_output(
         _ringbuf: *mut c_void,
         data: *const c_void,
@@ -142,12 +142,12 @@ mod tests {
         0
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn bpf_get_current_pid_tgid() -> u64 {
         1234u64 << 32
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn bpf_probe_read_user_str(_dst: *mut u8, _size: u32, _src: *const u8) -> i32 {
         0
     }


### PR DESCRIPTION
## Summary
- switch crates to Rust 2024 edition
- wrap unsafe attributes and extern block for Rust 2024 compatibility
- document new Rust edition and mark roadmap item complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b7e0bdb3a48332bb0feda6e5f5b509