### PR TITLE
feat(cli): add run command wrapper

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -13,7 +13,7 @@
 ## CLI
 - [x] Scaffold cargo subcommand `cargo warden`.
 - [x] Implement `build` wrapper that sets up cgroup, loads eBPF programs, and invokes Cargo.
-- [ ] Implement `run -- <cmd>` wrapper for arbitrary commands.
+- [x] Implement `run -- <cmd>` wrapper for arbitrary commands.
 - [ ] Add allowlist CLI option or config stub.
 
 ## Agent-lite


### PR DESCRIPTION
## Summary
- add `cargo warden run -- <cmd>` wrapper with isolation setup and command execution
- test run command formation and mark roadmap item complete

## Testing
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b89cc29cd883329b97dd45516e38d5