### PR TITLE
feat(cli): add allowlist option

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -14,7 +14,7 @@
 - [x] Scaffold cargo subcommand `cargo warden`.
 - [x] Implement `build` wrapper that sets up cgroup, loads eBPF programs, and invokes Cargo.
 - [x] Implement `run -- <cmd>` wrapper for arbitrary commands.
-- [ ] Add allowlist CLI option or config stub.
+- [x] Add allowlist CLI option or config stub.
 
 ## Agent-lite
 - [ ] Collect events from BPF maps and output text and JSON logs.


### PR DESCRIPTION
## Summary
- add global `--allow` flag and plumb it into build/run
- test parsing of allowlist values
- mark roadmap item complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b8a42d83288332b1b93cbaf1bdc331