### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo check --tests --benches
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo test
+      - run: cargo machete
+        continue-on-error: true

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -30,3 +30,4 @@
 - [ ] Provide script or Makefile to run examples under `cargo warden`.
 - [ ] Document setup requirements (BPF LSM, cgroup v2).
 - [x] Update code and docs to Rust 2024 edition.
+- [x] Add GitHub CI pipeline for formatting, linting, and tests.


### PR DESCRIPTION
## Summary
- add CI workflow running formatting, linting, and tests
- mark CI pipeline work as completed in roadmap

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `wrkflw validate .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b8b0a281608332a940cc6b307b769d