### PR TITLE
Add network-blocked build script example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "network-build"
+version = "0.1.0"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "crates/bpf-core",
     "crates/cli",
     "crates/agent-lite",
+    "examples/network-build",
 ]
 resolver = "2"

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -22,7 +22,7 @@
 - [x] Provide basic diagnostics for denied exec or network.
 
 ## Examples
-- [ ] Example crate with `build.rs` making a network request blocked by default.
+- [x] Example crate with `build.rs` making a network request blocked by default.
 - [ ] Example crate attempting to spawn `/bin/bash`.
 - [ ] Document expected `EPERM` results and hints.
 

--- a/examples/network-build/Cargo.toml
+++ b/examples/network-build/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "network-build"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/examples/network-build/README.md
+++ b/examples/network-build/README.md
@@ -1,0 +1,9 @@
+# Network Build Example
+
+This crate's `build.rs` script attempts to connect to `example.com:80`.
+When run under `cargo warden`, the network request is denied and the build
+script prints a warning such as:
+
+```text
+warning: network blocked: Operation not permitted (os error 1)
+```

--- a/examples/network-build/build.rs
+++ b/examples/network-build/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    match std::net::TcpStream::connect("example.com:80") {
+        Ok(_) => println!("cargo:warning=unexpected network success"),
+        Err(err) => println!("cargo:warning=network blocked: {err}"),
+    }
+}

--- a/examples/network-build/src/lib.rs
+++ b/examples/network-build/src/lib.rs
@@ -1,0 +1,2 @@
+/// No-op library used to demonstrate a network request in `build.rs`.
+pub fn touch() {}


### PR DESCRIPTION
## Summary
- add `network-build` example crate with a build script that warns when network access is denied
- add example to workspace and mark roadmap task complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b8cb4447c08332bd9e21d92fefe07f