### PR TITLE
Add spawn-bash example demonstrating exec denial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "spawn-bash"
+version = "0.1.0"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "crates/cli",
     "crates/agent-lite",
     "examples/network-build",
+    "examples/spawn-bash",
 ]
 resolver = "2"

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -23,8 +23,8 @@
 
 ## Examples
 - [x] Example crate with `build.rs` making a network request blocked by default.
-- [ ] Example crate attempting to spawn `/bin/bash`.
-- [ ] Document expected `EPERM` results and hints.
+- [x] Example crate attempting to spawn `/bin/bash`.
+- [x] Document expected `EPERM` results and hints.
 
 ## Cross-cutting
 - [ ] Provide script or Makefile to run examples under `cargo warden`.

--- a/examples/spawn-bash/Cargo.toml
+++ b/examples/spawn-bash/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "spawn-bash"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/examples/spawn-bash/README.md
+++ b/examples/spawn-bash/README.md
@@ -1,0 +1,10 @@
+# Spawn Bash Example
+
+This crate attempts to spawn `/bin/bash`.
+When run under `cargo warden`, the process creation is denied and prints an error like:
+
+```text
+spawn blocked: Permission denied (os error 1)
+```
+
+To allow this, add `/bin/bash` to the exec allowlist.

--- a/examples/spawn-bash/src/main.rs
+++ b/examples/spawn-bash/src/main.rs
@@ -1,0 +1,6 @@
+fn main() {
+    match std::process::Command::new("/bin/bash").spawn() {
+        Ok(_) => println!("spawned /bin/bash"),
+        Err(e) => eprintln!("spawn blocked: {e}"),
+    }
+}


### PR DESCRIPTION
## Summary
- add spawn-bash example showing blocked shell spawn under cargo warden
- document expected EPERM result in example README
- mark roadmap example tasks as completed

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68b8e122025883328ed25c28dd9cf9ed