### PR TITLE
docs: require reading spec and roadmaps

### DIFF
--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -1,4 +1,5 @@
 # Repository Agent Instructions
 
+- Before starting work, read `SPEC.md` and the roadmap files (`ROADMAP_PHASE1.md`, `ROADMAP_PHASE2.md`) to choose the next task.
 - After completing a task, mark it as done in `ROADMAP_PHASE1.md`.
 


### PR DESCRIPTION
## Summary
- instruct agents to read `SPEC.md` and roadmap files before choosing tasks

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68b960bce84883328fb90736f7d5807d