### PR TITLE
Add helper script for examples

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -27,7 +27,7 @@
 - [x] Document expected `EPERM` results and hints.
 
 ## Cross-cutting
-- [ ] Provide script or Makefile to run examples under `cargo warden`.
+- [x] Provide script or Makefile to run examples under `cargo warden`.
 - [x] Document setup requirements (BPF LSM, cgroup v2).
 - [x] Update code and docs to Rust 2024 edition.
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+# Examples
+
+Run both examples under `cargo warden` using the helper script:
+
+```bash
+./run_examples.sh
+```
+
+Expected output includes messages such as:
+
+```text
+== network-build ==
+warning: network blocked: Operation not permitted (os error 1)
+
+== spawn-bash ==
+spawn blocked: Permission denied (os error 1)
+```
+

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run network-build example
+printf '== network-build ==\n'
+(
+    cd examples/network-build
+    cargo run -p cargo-warden -- build
+)
+
+printf '\n== spawn-bash ==\n'
+(
+    cd examples/spawn-bash
+    cargo run -p cargo-warden -- run -- cargo run
+)
+


### PR DESCRIPTION
## Summary
- add script that runs network-build and spawn-bash under cargo warden
- document example usage and mark roadmap item

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`

------
https://chatgpt.com/codex/tasks/task_e_68b98744bb84833287e44278a93e202a