### PR TITLE
feat: add hierarchical net rules

### DIFF
--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -24,6 +24,13 @@ pub struct NetRuleEntry {
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
+pub struct NetParentEntry {
+    pub child: u32,
+    pub parent: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
 /// Event emitted by BPF programs.
 pub struct Event {
     /// Process identifier.
@@ -58,6 +65,11 @@ mod tests {
     #[test]
     fn net_rule_entry_size() {
         assert_eq!(size_of::<NetRuleEntry>(), 24);
+    }
+
+    #[test]
+    fn net_parent_entry_size() {
+        assert_eq!(size_of::<NetParentEntry>(), 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support parent-child network rule entries in bpf API
- consult hierarchical rule maps in cgroup hooks
- resolve DNS in tests for allowed and denied endpoints

## Testing
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68baf6258e18833296811d00e254bce5