### PR TITLE
feat: add policy core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "policy-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "spawn-bash"
 version = "0.1.0"
 
@@ -472,6 +490,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -579,6 +638,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/bpf-core",
     "crates/cli",
     "crates/agent-lite",
+    "crates/policy-core",
     "examples/network-build",
     "examples/spawn-bash",
 ]

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -35,3 +35,5 @@
 
 ## Phase 2 progress
 - [x] Provide `status` command displaying active policy and recent events.
+- [x] Design declarative policy schema in TOML.
+- [x] Emit warnings for unused or contradictory rules.

--- a/crates/policy-core/Cargo.toml
+++ b/crates/policy-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "policy-core"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+thiserror = "1"

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -1,0 +1,286 @@
+use serde::Deserialize;
+use std::{collections::HashSet, hash::Hash, path::PathBuf};
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Mode {
+    Observe,
+    Enforce,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FsDefault {
+    Strict,
+    Unrestricted,
+}
+
+impl Default for FsDefault {
+    fn default() -> Self {
+        Self::Strict
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum NetDefault {
+    Deny,
+    Allow,
+}
+
+impl Default for NetDefault {
+    fn default() -> Self {
+        Self::Deny
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecDefault {
+    Allowlist,
+    Allow,
+}
+
+impl Default for ExecDefault {
+    fn default() -> Self {
+        Self::Allowlist
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Policy {
+    pub mode: Mode,
+    #[serde(default)]
+    pub fs: FsPolicy,
+    #[serde(default)]
+    pub net: NetPolicy,
+    #[serde(default)]
+    pub exec: ExecPolicy,
+    #[serde(default)]
+    pub allow: AllowSection,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FsPolicy {
+    #[serde(default)]
+    pub default: FsDefault,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct NetPolicy {
+    #[serde(default)]
+    pub default: NetDefault,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ExecPolicy {
+    #[serde(default)]
+    pub default: ExecDefault,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct AllowSection {
+    #[serde(default)]
+    pub exec: ExecAllow,
+    #[serde(default)]
+    pub net: NetAllow,
+    #[serde(default)]
+    pub fs: FsAllow,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ExecAllow {
+    #[serde(default)]
+    pub allowed: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct NetAllow {
+    #[serde(default)]
+    pub hosts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct FsAllow {
+    #[serde(default)]
+    pub write_extra: Vec<PathBuf>,
+    #[serde(default)]
+    pub read_extra: Vec<PathBuf>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidationError {
+    #[error("duplicate exec allow rule: {0}")]
+    DuplicateExec(String),
+    #[error("duplicate net host rule: {0}")]
+    DuplicateNet(String),
+    #[error("duplicate fs write rule: {0}")]
+    DuplicateFsWrite(String),
+    #[error("duplicate fs read rule: {0}")]
+    DuplicateFsRead(String),
+    #[error("path {0} present in both read and write allowlists")]
+    FsReadWriteConflict(String),
+    #[error("exec allowlist is unused because exec.default is 'allow'")]
+    UnusedExecAllow,
+    #[error("network host allowlist is unused because net.default is 'allow'")]
+    UnusedNetAllow,
+    #[error("filesystem allowlists are unused because fs.default is 'unrestricted'")]
+    UnusedFsAllow,
+}
+
+impl Policy {
+    pub fn from_toml_str(toml_str: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(toml_str)
+    }
+
+    pub fn validate(&self) -> Result<(), Vec<ValidationError>> {
+        use ValidationError::*;
+        let mut errors = Vec::new();
+
+        if let Some(dup) = find_first_duplicate(&self.allow.exec.allowed) {
+            errors.push(DuplicateExec(dup));
+        }
+        if let Some(dup) = find_first_duplicate(&self.allow.net.hosts) {
+            errors.push(DuplicateNet(dup));
+        }
+        if let Some(dup) = find_first_duplicate(&self.allow.fs.write_extra) {
+            errors.push(DuplicateFsWrite(dup.to_string_lossy().into()));
+        }
+        if let Some(dup) = find_first_duplicate(&self.allow.fs.read_extra) {
+            errors.push(DuplicateFsRead(dup.to_string_lossy().into()));
+        }
+
+        let read_set: HashSet<_> = self.allow.fs.read_extra.iter().collect();
+        for w in &self.allow.fs.write_extra {
+            if read_set.contains(w) {
+                errors.push(FsReadWriteConflict(w.to_string_lossy().into()));
+            }
+        }
+
+        if self.exec.default == ExecDefault::Allow && !self.allow.exec.allowed.is_empty() {
+            errors.push(UnusedExecAllow);
+        }
+        if self.net.default == NetDefault::Allow && !self.allow.net.hosts.is_empty() {
+            errors.push(UnusedNetAllow);
+        }
+        if self.fs.default == FsDefault::Unrestricted
+            && (!self.allow.fs.read_extra.is_empty() || !self.allow.fs.write_extra.is_empty())
+        {
+            errors.push(UnusedFsAllow);
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+fn find_first_duplicate<T>(items: &[T]) -> Option<T>
+where
+    T: Eq + Hash + Clone,
+{
+    let mut seen = HashSet::new();
+    for item in items {
+        if !seen.insert(item.clone()) {
+            return Some(item.clone());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "deny"
+exec.default = "allowlist"
+
+[allow.exec]
+allowed = ["rustc", "rustdoc"]
+
+[allow.net]
+hosts = ["127.0.0.1:1080"]
+
+[allow.fs]
+write_extra = ["/tmp/warden-scratch"]
+read_extra = ["/usr/include"]
+"#;
+
+    #[test]
+    fn parse_and_validate() {
+        let policy = Policy::from_toml_str(VALID).unwrap();
+        policy.validate().unwrap();
+        assert_eq!(policy.mode, Mode::Enforce);
+    }
+
+    #[test]
+    fn duplicate_exec_detected() {
+        let text = r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "deny"
+exec.default = "allowlist"
+
+[allow.exec]
+allowed = ["bash", "bash"]
+"#;
+        let policy = Policy::from_toml_str(text).unwrap();
+        let errs = policy.validate().unwrap_err();
+        assert!(matches!(errs[0], ValidationError::DuplicateExec(_)));
+    }
+
+    #[test]
+    fn unused_net_rules_detected() {
+        let text = r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "allow"
+exec.default = "allow"
+
+[allow.net]
+hosts = ["1.2.3.4:80"]
+
+[allow.exec]
+allowed = ["bash"]
+"#;
+        let policy = Policy::from_toml_str(text).unwrap();
+        let errs = policy.validate().unwrap_err();
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::UnusedNetAllow))
+        );
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::UnusedExecAllow))
+        );
+    }
+
+    #[test]
+    fn fs_conflict_detected() {
+        let text = r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "deny"
+exec.default = "allowlist"
+
+[allow.fs]
+write_extra = ["/tmp/path", "/tmp/path"]
+read_extra = ["/tmp/path"]
+"#;
+        let policy = Policy::from_toml_str(text).unwrap();
+        let errs = policy.validate().unwrap_err();
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::DuplicateFsWrite(_)))
+        );
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::FsReadWriteConflict(_)))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `policy-core` crate defining TOML policy schema and validation
- parse `warden.toml` via serde/toml and check for duplicate or unused rules
- cover parsing and validation with unit tests

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bb0275159c8332b6e3af4281d60ee8