### PR TITLE
docs: remove phase 2 progress from phase 1 roadmap

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -33,7 +33,3 @@
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.
 - [x] Draft roadmap for Phase 2.
 
-## Phase 2 progress
-- [x] Provide `status` command displaying active policy and recent events.
-- [x] Design declarative policy schema in TOML.
-- [x] Emit warnings for unused or contradictory rules.


### PR DESCRIPTION
## Summary
- remove phase 2 progress block from phase 1 roadmap so upcoming work is tracked separately

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68bb377fc0448332a146083538d64f89