### PR TITLE
feat: add filesystem policy structures

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -33,3 +33,6 @@
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.
 - [x] Draft roadmap for Phase 2.
 
+## Phase 2 Progress
+- [x] Expose control for filesystem read/write policies in BPF API.
+

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -2,7 +2,7 @@
 
 ## BPF API
 - [x] Support per-package network rules via hierarchical maps.
-- [ ] Expose control for filesystem read/write policies.
+- [x] Expose control for filesystem read/write policies.
 - [ ] Document enriched event metadata such as container ID and capability bits.
 
 ## BPF Core

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,5 +1,10 @@
 #![no_std]
 
+/// Bit flag for read access.
+pub const FS_READ: u8 = 1;
+/// Bit flag for write access.
+pub const FS_WRITE: u8 = 2;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExecAllowEntry {
@@ -27,6 +32,21 @@ pub struct NetRuleEntry {
 pub struct NetParentEntry {
     pub child: u32,
     pub parent: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FsRule {
+    pub access: u8,
+    pub reserved: [u8; 3],
+    pub path: [u8; 256],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct FsRuleEntry {
+    pub unit: u32,
+    pub rule: FsRule,
 }
 
 #[repr(C)]
@@ -70,6 +90,16 @@ mod tests {
     #[test]
     fn net_parent_entry_size() {
         assert_eq!(size_of::<NetParentEntry>(), 8);
+    }
+
+    #[test]
+    fn fs_rule_size() {
+        assert_eq!(size_of::<FsRule>(), 260);
+    }
+
+    #[test]
+    fn fs_rule_entry_size() {
+        assert_eq!(size_of::<FsRuleEntry>(), 264);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add bitflags and structs for filesystem access rules in BPF API
- mark filesystem policy task completed in roadmaps

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bb38c7d90c83329294167213169901