### PR TITLE
Document container and capability metadata in event logs

### DIFF
--- a/EVENT_LOG_ABI.md
+++ b/EVENT_LOG_ABI.md
@@ -11,6 +11,8 @@ pub struct Event {
     pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
     pub verdict: u8,     // 0 Allowed, 1 Denied
     pub reserved: u8,    // padding for alignment, reserved for future use
+    pub container_id: u64,
+    pub caps: u64,       // Linux capability bitmask
     pub path_or_addr: [u8; 256], // null-terminated path or network address
 }
 ```
@@ -20,4 +22,6 @@ pub struct Event {
 - **action** – operation being audited.
 - **path_or_addr** – associated filesystem path or network address.
 - **verdict** – allow (`0`) or deny (`1`).
+- **container_id** – identifier of the container or sandbox.
+- **caps** – Linux capability bitmask held by the process.
 

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -35,4 +35,5 @@
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.
+- [x] Document enriched event metadata such as container ID and capability bits.
 

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -3,7 +3,7 @@
 ## BPF API
 - [x] Support per-package network rules via hierarchical maps.
 - [x] Expose control for filesystem read/write policies.
-- [ ] Document enriched event metadata such as container ID and capability bits.
+ - [x] Document enriched event metadata such as container ID and capability bits.
 
 ## BPF Core
 - [x] Enforce network allowlists with CIDR matching and DNS resolution.

--- a/crates/agent-lite/src/lib.rs
+++ b/crates/agent-lite/src/lib.rs
@@ -15,6 +15,8 @@ pub struct EventRecord {
     pub unit: u8,
     pub action: u8,
     pub verdict: u8,
+    pub container_id: u64,
+    pub caps: u64,
     pub path_or_addr: String,
 }
 
@@ -31,6 +33,8 @@ impl From<Event> for EventRecord {
             unit: e.unit,
             action: e.action,
             verdict: e.verdict,
+            container_id: e.container_id,
+            caps: e.caps,
             path_or_addr,
         }
     }
@@ -40,8 +44,14 @@ impl std::fmt::Display for EventRecord {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "pid={} unit={} action={} verdict={} path_or_addr={}",
-            self.pid, self.unit, self.action, self.verdict, self.path_or_addr
+            "pid={} unit={} action={} verdict={} container_id={} caps={} path_or_addr={}",
+            self.pid,
+            self.unit,
+            self.action,
+            self.verdict,
+            self.container_id,
+            self.caps,
+            self.path_or_addr
         )
     }
 }
@@ -90,6 +100,8 @@ mod tests {
             action: 2,
             verdict: 0,
             reserved: 0,
+            container_id: 7,
+            caps: 1,
             path_or_addr: path,
         };
         let record: EventRecord = event.into();
@@ -97,6 +109,8 @@ mod tests {
         assert_eq!(record.unit, 1);
         assert_eq!(record.action, 2);
         assert_eq!(record.verdict, 0);
+        assert_eq!(record.container_id, 7);
+        assert_eq!(record.caps, 1);
         assert_eq!(record.path_or_addr, "/bin");
         let text = format!("{}", record);
         assert!(text.contains("pid=42"));
@@ -111,6 +125,8 @@ mod tests {
             unit: 0,
             action: ACTION_EXEC,
             verdict: VERDICT_DENIED,
+            container_id: 0,
+            caps: 0,
             path_or_addr: "/bin/bash".into(),
         };
         assert_eq!(
@@ -122,6 +138,8 @@ mod tests {
             unit: 0,
             action: ACTION_CONNECT,
             verdict: VERDICT_DENIED,
+            container_id: 0,
+            caps: 0,
             path_or_addr: "1.2.3.4:80".into(),
         };
         assert_eq!(
@@ -133,6 +151,8 @@ mod tests {
             unit: 0,
             action: ACTION_EXEC,
             verdict: 0,
+            container_id: 0,
+            caps: 0,
             path_or_addr: "/bin/bash".into(),
         };
         assert!(diagnostic(&allow).is_none());

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -63,6 +63,10 @@ pub struct Event {
     pub verdict: u8,
     /// Reserved for future use.
     pub reserved: u8,
+    /// Identifier of the container or sandbox.
+    pub container_id: u64,
+    /// Bitmask of Linux capabilities held by the process.
+    pub caps: u64,
     /// Null-terminated path or network address.
     pub path_or_addr: [u8; 256],
 }
@@ -104,6 +108,6 @@ mod tests {
 
     #[test]
     fn event_size() {
-        assert_eq!(size_of::<Event>(), 264);
+        assert_eq!(size_of::<Event>(), 280);
     }
 }

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -249,6 +249,8 @@ pub extern "C" fn file_open(_file: *mut c_void, _cred: *mut c_void) -> i32 {
         action: 0,
         verdict: 0,
         reserved: 0,
+        container_id: 0,
+        caps: 0,
         path_or_addr: [0; 256],
     };
     unsafe {


### PR DESCRIPTION
## Summary
- extend BPF event records with container ID and capability bitmask
- expose new fields through agent and update event log ABI docs
- mark roadmap item as completed

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a4dce1083328b9c5a5d6329108a