### PR TITLE
Add seccomp-based syscall filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags",
+ "bitflags 2.9.4",
  "bytes",
  "libc",
  "log",
@@ -111,6 +111,12 @@ dependencies = [
  "object",
  "thiserror",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -140,6 +146,9 @@ name = "cargo-warden"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "libc",
+ "libseccomp",
+ "policy-core",
  "tempfile",
 ]
 
@@ -299,6 +308,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libseccomp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "policy-core"
 version = "0.1.0"
 dependencies = [
@@ -383,7 +416,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -8,7 +8,7 @@
 ## BPF Core
 - [x] Enforce network allowlists with CIDR matching and DNS resolution.
 - [x] Add hooks for file write and delete operations with deny by default.
-- [ ] Implement configurable syscall filtering via seccomp integration.
+- [x] Implement configurable syscall filtering via seccomp integration.
 - [ ] Provide metrics maps for event counters.
 
 ## CLI

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+libseccomp = "0.3"
+libc = "0.2"
+policy-core = { path = "../policy-core" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add syscall deny list to policy core with validation
- integrate seccomp filters into CLI
- mark roadmap item for seccomp filtering complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bdcedc95448332bc607b55c22262e2