### PR TITLE
Remove Phase 2 tasks from Phase 1 roadmap

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -33,9 +33,3 @@
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.
 - [x] Draft roadmap for Phase 2.
 
-## Phase 2 Progress
-- [x] Expose control for filesystem read/write policies in BPF API.
-- [x] Document enriched event metadata such as container ID and capability bits.
-- [x] Support `--policy` flag referencing external policy files.
-- [x] Add hooks for file write and delete operations with deny by default.
-


### PR DESCRIPTION
## Summary
- remove Phase 2 progress section from Phase 1 roadmap

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68bdddc4aa3c8332b53bdf02faa4ae23