### PR TITLE
feat: report policy warnings

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -35,4 +35,6 @@
 
 ## Phase 2 Progress
 - [x] Design declarative policy schema in TOML.
+- [x] Validate policies against schema during CLI commands.
+- [x] Emit warnings for unused or contradictory rules.
 

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -19,9 +19,9 @@
 
 ## Policy Engine
 - [x] Design declarative policy schema in TOML.
-- [ ] Validate policies against schema during CLI commands.
+- [x] Validate policies against schema during CLI commands.
 - [ ] Support policy inheritance and overrides per workspace member.
-- [ ] Emit warnings for unused or contradictory rules.
+- [x] Emit warnings for unused or contradictory rules.
 
 ## Agent
 - [ ] Stream events to JSONL file and systemd journal simultaneously.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -87,11 +87,15 @@ fn setup_isolation(_allow: &[String], policy: &[String]) -> io::Result<Vec<Strin
         let text = std::fs::read_to_string(path)?;
         let policy = policy_core::Policy::from_toml_str(&text)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        if let Err(errs) = policy.validate() {
+        let report = policy.validate();
+        if !report.errors.is_empty() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                format!("{:?}", errs),
+                format!("{:?}", report.errors),
             ));
+        }
+        for warn in report.warnings {
+            eprintln!("warning: {warn}");
         }
         Ok(policy.syscall.deny)
     } else {


### PR DESCRIPTION
## Summary
- distinguish policy validation warnings from errors
- surface policy warnings without aborting CLI runs
- check off completed policy tasks in the roadmap

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bde3cc410083329c1f515728d5e930