### PR TITLE
docs(roadmap): restore Phase 2 tasks

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -34,6 +34,10 @@
 - [x] Draft roadmap for Phase 2.
 
 ## Phase 2 Progress
+- [x] Expose control for filesystem read/write policies in BPF API.
+- [x] Document enriched event metadata such as container ID and capability bits.
+- [x] Support `--policy` flag referencing external policy files.
+- [x] Add hooks for file write and delete operations with deny by default.
 - [x] Design declarative policy schema in TOML.
 - [x] Validate policies against schema during CLI commands.
 - [x] Emit warnings for unused or contradictory rules.


### PR DESCRIPTION
## Summary
- restore Phase 2 progress items in Phase 1 roadmap

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bde5855ef08332aa2a1911edf20e5a