### PR TITLE
Add workspace policy overrides and dual logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,11 @@ dependencies = [
  "anyhow",
  "aya",
  "bpf-api",
+ "log",
  "serde",
  "serde_json",
+ "systemd-journal-logger",
+ "tempfile",
 ]
 
 [[package]]
@@ -489,6 +492,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "systemd-journal-logger"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266304d24ca5a4b230545fc558c80e18bd3e1d2eb1be149b6bcd04398d3e79c"
+dependencies = [
+ "log",
+ "rustix",
 ]
 
 [[package]]

--- a/POLICY_SCHEMA.md
+++ b/POLICY_SCHEMA.md
@@ -62,3 +62,17 @@ Additional paths allowed for reading when `fs.default = "strict"`.
 
 ### `syscall.deny`
 System calls blocked via seccomp.
+
+## Workspace Policy
+`workspace.warden.toml` allows per-package overrides.
+
+```toml
+[root]
+mode = "enforce"
+
+[members.pkg.exec]
+default = "allow"
+```
+
+The `root` table defines the base policy applied to all workspace members.
+Entries under `members.<name>` override fields for that specific package.

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -41,4 +41,6 @@
 - [x] Design declarative policy schema in TOML.
 - [x] Validate policies against schema during CLI commands.
 - [x] Emit warnings for unused or contradictory rules.
+- [x] Support policy inheritance and overrides per workspace member.
+- [x] Stream events to JSONL file and systemd journal simultaneously.
 

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -20,11 +20,11 @@
 ## Policy Engine
 - [x] Design declarative policy schema in TOML.
 - [x] Validate policies against schema during CLI commands.
-- [ ] Support policy inheritance and overrides per workspace member.
+ - [x] Support policy inheritance and overrides per workspace member.
 - [x] Emit warnings for unused or contradictory rules.
 
 ## Agent
-- [ ] Stream events to JSONL file and systemd journal simultaneously.
+ - [x] Stream events to JSONL file and systemd journal simultaneously.
 - [ ] Offer configurable log rotation and retention settings.
 - [ ] Provide optional gRPC endpoint for remote monitoring.
 

--- a/crates/agent-lite/Cargo.toml
+++ b/crates/agent-lite/Cargo.toml
@@ -11,3 +11,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 anyhow = "1"
+log = "0.4"
+systemd-journal-logger = "2.2"
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- Support per-package policy overrides with inheritance in workspace policies (`WorkspacePolicy`) [F:crates/policy-core/src/lib.rs#L123-L162]
- Stream agent events to JSONL files and systemd journal [F:crates/agent-lite/src/lib.rs#L74-L101]
- Document workspace policy schema [F:POLICY_SCHEMA.md#L66-L78]
- Mark roadmap items as complete [F:ROADMAP_PHASE2.md#L23][F:ROADMAP_PHASE2.md#L27]

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bde86f2fe48332a7a22f0cb71b3f54