### PR TITLE
Add cargo-deny dependency auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
       - run: cargo check --tests --benches
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test
+      - run: cargo deny check
       - run: cargo machete
         continue-on-error: true

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -48,4 +48,5 @@
 - [x] Provide Docker image with runtime dependencies preinstalled.
 - [x] Merge multiple policy files referenced via CLI.
 - [x] Replace polling with blocking ring buffer reads in agent.
+- [x] Integrate `cargo-deny` for dependency auditing.
 

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -36,7 +36,7 @@
 ## CI and Tooling
 - [ ] Expand CI to test examples under multiple kernel versions.
 - [ ] Add fuzzing harness for BPF programs.
-- [ ] Integrate `cargo-deny` for dependency auditing.
+ - [x] Integrate `cargo-deny` for dependency auditing.
 
 ## Cross-cutting
 - [ ] Write end-to-end tutorial covering policy creation and enforcement.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,13 @@
+# Cargo-deny configuration for cargo-warden
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[licenses]
+allow = ["MIT", "Apache-2.0"]
+confidence-threshold = 0.8
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"


### PR DESCRIPTION
## Summary
- run `cargo deny check` in CI
- add `deny.toml` configuration
- mark roadmap items complete for cargo-deny integration

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo deny check` *(fails: failed to fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfeda2ba083328dabcba9e83bdc43