### PR TITLE
Add Phase 3 roadmap for reports and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - run: cargo fmt --all -- --check
       - run: cargo check --tests --benches
       - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -32,6 +32,7 @@
 - [x] Update code and docs to Rust 2024 edition.
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.
 - [x] Draft roadmap for Phase 2.
+- [x] Draft roadmap for Phase 3.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -1,0 +1,17 @@
+# Phase 3 Roadmap – Reports and CI Integration
+
+## Reporting
+- [ ] Export violation events to SARIF for PR annotations.
+- [ ] Upload SARIF reports in GitHub workflow.
+
+## Metrics
+- [ ] Extend agent-lite to expose Prometheus metrics.
+- [ ] Provide example Prometheus dashboard.
+
+## GitHub Action
+- [ ] Publish `warden-ci` GitHub Action with minimal workflow.
+- [ ] Document usage in `.github/workflows/warden-ci.yml`.
+
+## Cross-cutting
+- [ ] PR with violation displays SARIF annotations.
+- [ ] Metrics dashboard works out of the box.


### PR DESCRIPTION
## Summary
- add Phase 3 roadmap for reports and CI integration
- record Phase 3 roadmap task as completed in phase 1

## Testing
- `cargo fmt --all`

------
https://chatgpt.com/codex/tasks/task_e_68be06763b508332a3aea3cd15feb3c5