### PR TITLE
Add warden-ci workflow example

### DIFF
--- a/.github/workflows/warden-ci.yml
+++ b/.github/workflows/warden-ci.yml
@@ -1,0 +1,18 @@
+name: warden-ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install cargo-warden
+        run: cargo install --path crates/cli
+      - name: Enforce build
+        run: cargo warden build

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -54,3 +54,6 @@
 - [x] Document security model and threat considerations.
 - [x] Write end-to-end tutorial covering policy creation and enforcement.
 
+## Phase 3 Progress
+- [x] Document usage in `.github/workflows/warden-ci.yml`.
+

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -10,7 +10,7 @@
 
 ## GitHub Action
 - [ ] Publish `warden-ci` GitHub Action with minimal workflow.
-- [ ] Document usage in `.github/workflows/warden-ci.yml`.
+- [x] Document usage in `.github/workflows/warden-ci.yml`.
 
 ## Cross-cutting
 - [ ] PR with violation displays SARIF annotations.


### PR DESCRIPTION
## Summary
- add example GitHub workflow for running `cargo warden`
- track workflow documentation progress in phase roadmaps

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bebac0f2348332b03c132ba0bfac32