### PR TITLE
Add distribution archive script

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -54,6 +54,7 @@
 - [x] Document security model and threat considerations.
 - [x] Write end-to-end tutorial covering policy creation and enforcement.
 - [x] Publish prebuilt BPF artifacts for common architectures.
+- [x] Generate distributable archive with CLI and agent binaries.
 
 ## Phase 3 Progress
 - [x] Document usage in `.github/workflows/warden-ci.yml`.

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -31,7 +31,7 @@
 ## Packaging and Distribution
 - [x] Publish prebuilt BPF artifacts for common architectures.
 - [x] Provide Docker image with runtime dependencies preinstalled.
-- [ ] Generate distributable archive with CLI and agent binaries.
+- [x] Generate distributable archive with CLI and agent binaries.
 
 ## CI and Tooling
 - [ ] Expand CI to test examples under multiple kernel versions.

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build release binaries for CLI and agent
+cargo build --release -p cargo-warden -p agent-lite
+
+# Determine version from CLI crate
+VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/cli/Cargo.toml)
+ARCH=$(uname -m)
+OUTDIR=dist
+mkdir -p "$OUTDIR"
+
+# Choose agent artifact: binary if available, otherwise library
+AGENT_PATH="target/release/agent-lite"
+if [[ ! -f "$AGENT_PATH" ]]; then
+    AGENT_PATH="target/release/libagent_lite.rlib"
+fi
+
+TARFILE="$OUTDIR/cargo-warden-$VERSION-$ARCH.tar.gz"
+tar -C target/release -czf "$TARFILE" cargo-warden $(basename "$AGENT_PATH")
+echo "Created $TARFILE"


### PR DESCRIPTION
## Summary
- add build-dist.sh to package CLI and agent artifacts
- mark distribution task in roadmaps

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68bf61a526888332b631ef91afeaeb6b