### PR TITLE
ci: test examples on multiple kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,16 @@ jobs:
       - run: cargo test
       - run: cargo machete
         continue-on-error: true
+
+  examples:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libseccomp-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: ./run_examples.sh

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -55,6 +55,7 @@
 - [x] Write end-to-end tutorial covering policy creation and enforcement.
 - [x] Publish prebuilt BPF artifacts for common architectures.
 - [x] Generate distributable archive with CLI and agent binaries.
+- [x] Expand CI to test examples under multiple kernel versions.
 
 ## Phase 3 Progress
 - [x] Document usage in `.github/workflows/warden-ci.yml`.

--- a/ROADMAP_PHASE2.md
+++ b/ROADMAP_PHASE2.md
@@ -34,7 +34,7 @@
 - [x] Generate distributable archive with CLI and agent binaries.
 
 ## CI and Tooling
-- [ ] Expand CI to test examples under multiple kernel versions.
+- [x] Expand CI to test examples under multiple kernel versions.
 - [ ] Add fuzzing harness for BPF programs.
 - [x] Integrate `cargo-deny` for dependency auditing.
 


### PR DESCRIPTION
## Summary
- run example builds on Ubuntu 22.04 and 24.04 in CI
- mark roadmap item for cross-kernel example testing as complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c0271fb73c833296a4a3477139a237