### PR TITLE
docs: expand roadmap with CI tools

### DIFF
--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -32,6 +32,7 @@
 - [x] Update code and docs to Rust 2024 edition.
 - [x] Add GitHub CI pipeline for formatting, linting, and tests.
 - [x] Install cargo-deny in CI pipeline for dependency auditing.
+- [x] Plan additional CI tooling: cargo-audit, cargo-udeps, cargo-llvm-cov, cargo-nextest, cargo-spellcheck, actionlint.
 - [x] Draft roadmap for Phase 2.
 - [x] Draft roadmap for Phase 3.
 

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -12,6 +12,17 @@
 - [ ] Publish `warden-ci` GitHub Action with minimal workflow.
 - [x] Document usage in `.github/workflows/warden-ci.yml`.
 
+## CI and Tooling
+- [ ] Integrate `cargo-audit` for dependency vulnerability checks.
+- [ ] Integrate `cargo-udeps` to detect unused dependencies.
+- [ ] Add coverage reports using `cargo-llvm-cov`.
+- [ ] Adopt `cargo-nextest` for parallel test execution.
+- [ ] Run `cargo-spellcheck` for documentation consistency.
+- [ ] Use `actionlint` to validate GitHub workflow files.
+
+## GeoSeqOps
+- [ ] Evaluate requirements and integration approach for GeoSeqOps module.
+
 ## Cross-cutting
 - [ ] PR with violation displays SARIF annotations.
 - [ ] Metrics dashboard works out of the box.


### PR DESCRIPTION
## Summary
- document future CI tooling and coverage additions
- note GeoSeqOps module for exploration
- record CI planning in Phase 1 roadmap

## Testing
- `cargo fmt --all`


------
https://chatgpt.com/codex/tasks/task_e_68c0daee2f688332866d2293dff1217e