### PR TITLE
ci: add actionlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
     branches: [main]
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-check
+          github_token: ${{ secrets.GITHUB_TOKEN }}
   check:
     runs-on: ubuntu-latest
     steps:

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -62,4 +62,5 @@
 ## Phase 3 Progress
 - [x] Document usage in `.github/workflows/warden-ci.yml`.
 - [x] Export violation events to SARIF for PR annotations.
+- [x] Use actionlint to validate GitHub workflow files.
 

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -18,7 +18,7 @@
 - [ ] Add coverage reports using `cargo-llvm-cov`.
 - [ ] Adopt `cargo-nextest` for parallel test execution.
 - [ ] Run `cargo-spellcheck` for documentation consistency.
-- [ ] Use `actionlint` to validate GitHub workflow files.
+- [x] Use `actionlint` to validate GitHub workflow files.
 
 ## Cross-cutting
 - [ ] PR with violation displays SARIF annotations.


### PR DESCRIPTION
## Summary
- lint GitHub workflows with actionlint
- mark actionlint task complete in roadmaps

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c17b76e64883328c09b9b01b4be88e