### PR TITLE
ci: add cargo audit and udeps checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,21 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-machete
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
       - run: cargo fmt --all -- --check
       - run: cargo check --tests --benches
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test
       - run: cargo machete
         continue-on-error: true
+      - run: cargo audit
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo +nightly udeps --all-targets --all-features
 
   examples:
     strategy:

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -64,4 +64,6 @@
 - [x] Document usage in `.github/workflows/warden-ci.yml`.
 - [x] Export violation events to SARIF for PR annotations.
 - [x] Use actionlint to validate GitHub workflow files.
+- [x] Integrate `cargo-audit` for dependency vulnerability checks.
+- [x] Integrate `cargo-udeps` to detect unused dependencies.
 

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -13,8 +13,8 @@
 - [x] Document usage in `.github/workflows/warden-ci.yml`.
 
 ## CI and Tooling
-- [ ] Integrate `cargo-audit` for dependency vulnerability checks.
-- [ ] Integrate `cargo-udeps` to detect unused dependencies.
+ - [x] Integrate `cargo-audit` for dependency vulnerability checks.
+ - [x] Integrate `cargo-udeps` to detect unused dependencies.
 - [ ] Add coverage reports using `cargo-llvm-cov`.
 - [ ] Adopt `cargo-nextest` for parallel test execution.
 - [ ] Run `cargo-spellcheck` for documentation consistency.


### PR DESCRIPTION
## Summary
- run cargo-audit and cargo-udeps in CI
- mark roadmap tasks as complete

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo audit --no-fetch`
- `cargo +nightly udeps --all-targets --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68c189768d8c83329b3815e7c42e0f3c