### PR TITLE
ci: run tests with cargo-nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-udeps
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - run: cargo fmt --all -- --check
       - run: cargo check --tests --benches
       - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo test
+      - run: cargo nextest run
       - run: cargo machete
         continue-on-error: true
       - run: cargo audit

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -66,4 +66,5 @@
 - [x] Use actionlint to validate GitHub workflow files.
 - [x] Integrate `cargo-audit` for dependency vulnerability checks.
 - [x] Integrate `cargo-udeps` to detect unused dependencies.
+- [x] Adopt `cargo-nextest` for parallel test execution.
 

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -16,7 +16,7 @@
  - [x] Integrate `cargo-audit` for dependency vulnerability checks.
  - [x] Integrate `cargo-udeps` to detect unused dependencies.
 - [ ] Add coverage reports using `cargo-llvm-cov`.
-- [ ] Adopt `cargo-nextest` for parallel test execution.
+- [x] Adopt `cargo-nextest` for parallel test execution.
 - [ ] Run `cargo-spellcheck` for documentation consistency.
 - [x] Use `actionlint` to validate GitHub workflow files.
 


### PR DESCRIPTION
## Summary
- run tests in CI with `cargo nextest`
- record `cargo-nextest` adoption in roadmap

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c1b13322d483329501f637faaae846