### PR TITLE
Add warden-ci composite action and sample workflow

### DIFF
--- a/.github/workflows/warden-ci.yml
+++ b/.github/workflows/warden-ci.yml
@@ -8,22 +8,4 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libseccomp-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install cargo-warden
-        run: cargo install --path crates/cli
-      - name: Enforce build
-        run: cargo warden build || true
-      - name: Generate SARIF report
-        run: cargo warden report --output warden.sarif
-      - name: Upload SARIF report
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: warden.sarif
-        continue-on-error: true
+      - uses: ./warden-ci

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -72,4 +72,5 @@
 
 - [x] Upload SARIF reports in GitHub workflow.
 - [x] Provide example Prometheus dashboard.
+- [x] Publish `warden-ci` GitHub Action with minimal workflow.
 

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -9,7 +9,7 @@
 - [x] Provide example Prometheus dashboard.
 
 ## GitHub Action
-- [ ] Publish `warden-ci` GitHub Action with minimal workflow.
+- [x] Publish `warden-ci` GitHub Action with minimal workflow.
 - [x] Document usage in `.github/workflows/warden-ci.yml`.
 
 ## CI and Tooling

--- a/warden-ci/README.md
+++ b/warden-ci/README.md
@@ -1,0 +1,27 @@
+# warden-ci GitHub Action
+
+Runs `cargo-warden` in CI, generates a SARIF report and uploads it for pull request annotations.
+
+## Inputs
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `command` | Cargo command to run under `cargo-warden`. | `build` |
+
+## Usage
+
+```yaml
+name: warden-ci
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: owner/warden-ci@v1
+        with:
+          command: build
+```

--- a/warden-ci/action.yml
+++ b/warden-ci/action.yml
@@ -1,0 +1,33 @@
+name: 'warden-ci'
+description: 'Run cargo-warden in CI and upload SARIF report.'
+inputs:
+  command:
+    description: 'Cargo command to run under cargo-warden'
+    required: false
+    default: 'build'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y pkg-config libseccomp-dev
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Install cargo-warden
+      shell: bash
+      run: cargo install --path crates/cli
+    - name: Enforce ${{ inputs.command }}
+      shell: bash
+      run: cargo warden ${{ inputs.command }} || true
+    - name: Generate SARIF report
+      shell: bash
+      run: cargo warden report --output warden.sarif
+    - name: Upload SARIF report
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        sarif_file: warden.sarif
+      continue-on-error: true


### PR DESCRIPTION
## Summary
- provide `warden-ci` composite action that installs cargo-warden and uploads SARIF
- simplify example workflow to use the new action
- mark roadmap items for publishing the action

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `actionlint .github/workflows/warden-ci.yml` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c23472924c8332ba288a53b463b2ee