### PR TITLE
Add actionlint setup script

### DIFF
--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -4,4 +4,5 @@
 - Use avatars from the MCP server at `https://qqrm.github.io/avatars-mcp/` for all work.
 - Before starting work, read `SPEC.md` and the roadmap files (`ROADMAP_PHASE1.md`, `ROADMAP_PHASE2.md`) to choose the next task.
 - After completing a task, mark it as done in `ROADMAP_PHASE1.md`.
+- Run `./local_setup.sh` to install `actionlint` for linting GitHub workflows.
 

--- a/local_setup.sh
+++ b/local_setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install actionlint for GitHub Actions workflow linting.
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "Installing actionlint..."
+  curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest "$HOME/.local/bin"
+  export PATH="$HOME/.local/bin:$PATH"
+fi


### PR DESCRIPTION
## Summary
- install actionlint via local setup script
- document actionlint setup in repository agent instructions

## Testing
- `actionlint`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c2421047f883329f50a1487902a036