### PR TITLE
Add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -36,6 +36,7 @@
 - [x] Plan additional DevSecOps tooling: cargo-audit, cargo-udeps, cargo-llvm-cov, cargo-nextest, cargo-spellcheck, actionlint.
 - [x] Draft roadmap for Phase 2.
 - [x] Draft roadmap for Phase 3.
+- [x] Add GitHub publish workflow for crates.io releases.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.


### PR DESCRIPTION
## Summary
- add publish workflow that releases crate on tagged pushes or manual dispatch
- record publish workflow completion in roadmap

## Testing
- `actionlint .github/workflows/publish.yml`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c24d72569483328261d659179a01b6