### PR TITLE
Fix publish workflow package selection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+      - run: cargo publish -p cargo-warden --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## Summary
- specify `cargo-warden` crate when publishing

## Testing
- `actionlint .github/workflows/publish.yml`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c31b0bef008332af89f6969c710064