### PR TITLE
Use CI environment for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: prod
+    environment: CI
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- use CI environment to access CRATES_IO_TOKEN secret in publish workflow

## Testing
- `actionlint .github/workflows/publish.yml`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c32ad3ff1483328023f4359a6cf50b