### PR TITLE
fix publish workflow to release dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo publish -p policy-core --token ${{ secrets.CRATES_IO_TOKEN }}
       - run: cargo publish -p cargo-warden --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -39,6 +39,7 @@
 - [x] Draft roadmap for Phase 2.
 - [x] Draft roadmap for Phase 3.
 - [x] Add GitHub publish workflow for crates.io releases.
+- [x] Publish policy-core before cargo-warden in release workflow.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 clap = { version = "4", features = ["derive"] }
 libseccomp = "0.3"
 libc = "0.2"
-policy-core = { path = "../policy-core" }
+policy-core = { version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 


### PR DESCRIPTION
## Summary
- publish policy-core before cargo-warden
- record publish workflow change in roadmap
- specify policy-core version in cargo-warden

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68c38752ba7c8332971275d6d620efc9