### PR TITLE
Publish all workspace crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,5 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish -p policy-core --token ${{ secrets.CRATES_IO_TOKEN }}
-      - run: cargo publish -p cargo-warden --token ${{ secrets.CRATES_IO_TOKEN }}
+      - run: |
+          set -e
+          crates="bpf-api bpf-core policy-core policy-compiler agent-lite testkits cargo-warden"
+          for crate in $crates; do
+            cargo publish -p "$crate" --token "${{ secrets.CRATES_IO_TOKEN }}"
+          done


### PR DESCRIPTION
## Summary
- publish every workspace crate in the release workflow

## Testing
- `actionlint .github/workflows/publish.yml`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c3e85b5c608332a18e353a5e936b79