### PR TITLE
Prefix internal crates with qqrm to avoid name collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,31 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "agent-lite"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aya",
- "bpf-api",
- "futures-core",
- "futures-util",
- "libc",
- "log",
- "prometheus",
- "prost",
- "serde",
- "serde_json",
- "serial_test",
- "systemd-journal-logger",
- "tempfile",
- "tiny_http",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,34 +264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
-name = "bpf-api"
-version = "0.1.0"
-
-[[package]]
-name = "bpf-core"
-version = "0.1.0"
-dependencies = [
- "bpf-api",
-]
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
-name = "cargo-warden"
-version = "0.1.0"
-dependencies = [
- "clap",
- "libc",
- "libseccomp",
- "policy-core",
- "serde",
- "serde_json",
- "tempfile",
-]
 
 [[package]]
 name = "cfg-if"
@@ -819,10 +770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "network-build"
-version = "0.1.0"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,23 +878,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "policy-compiler"
-version = "0.1.0"
-dependencies = [
- "policy-core",
-]
-
-[[package]]
-name = "policy-core"
-version = "0.1.0"
-dependencies = [
- "proptest",
- "serde",
- "thiserror 1.0.69",
- "toml",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1084,6 +1014,84 @@ checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "qqrm-agent-lite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aya",
+ "futures-core",
+ "futures-util",
+ "libc",
+ "log",
+ "prometheus",
+ "prost",
+ "qqrm-bpf-api",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "systemd-journal-logger",
+ "tempfile",
+ "tiny_http",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "qqrm-bpf-api"
+version = "0.1.0"
+
+[[package]]
+name = "qqrm-bpf-core"
+version = "0.1.0"
+dependencies = [
+ "qqrm-bpf-api",
+]
+
+[[package]]
+name = "qqrm-cargo-warden"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "libc",
+ "libseccomp",
+ "qqrm-policy-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "qqrm-network-build"
+version = "0.1.0"
+
+[[package]]
+name = "qqrm-policy-compiler"
+version = "0.1.0"
+dependencies = [
+ "qqrm-policy-core",
+]
+
+[[package]]
+name = "qqrm-policy-core"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "serde",
+ "thiserror 1.0.69",
+ "toml",
+]
+
+[[package]]
+name = "qqrm-spawn-bash"
+version = "0.1.0"
+
+[[package]]
+name = "qqrm-testkits"
+version = "0.1.0"
 
 [[package]]
 name = "quick-error"
@@ -1375,10 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spawn-bash"
-version = "0.1.0"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,10 +1427,6 @@ dependencies = [
  "rustix",
  "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "testkits"
-version = "0.1.0"
 
 [[package]]
 name = "thiserror"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM rust:1 AS build
 WORKDIR /src
 COPY . .
-RUN cargo build --release -p cli -p agent-lite
+RUN cargo build --release -p qqrm-cargo-warden -p qqrm-agent-lite
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libbpf-dev bpftool ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/target/release/cargo-warden /usr/local/bin/
-COPY --from=build /src/target/release/agent-lite /usr/local/bin/
+COPY --from=build /src/target/release/qqrm-agent-lite /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/cargo-warden"]

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -39,8 +39,9 @@
 - [x] Draft roadmap for Phase 2.
 - [x] Draft roadmap for Phase 3.
 - [x] Add GitHub publish workflow for crates.io releases.
-- [x] Publish policy-core before cargo-warden in release workflow.
+- [x] Publish qqrm-policy-core before qqrm-cargo-warden in release workflow.
 - [x] Fix publish workflow to use CI environment for secrets.
+- [x] Prefix crate names with `qqrm-` to avoid crates.io collisions.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.

--- a/ROADMAP_PHASE3.md
+++ b/ROADMAP_PHASE3.md
@@ -5,7 +5,7 @@
 - [x] Upload SARIF reports in GitHub workflow.
 
 ## Metrics
-- [x] Extend agent-lite to expose Prometheus metrics.
+- [x] Extend qqrm-agent-lite to expose Prometheus metrics.
 - [x] Provide example Prometheus dashboard.
 
 ## GitHub Action

--- a/SPEC.md
+++ b/SPEC.md
@@ -80,32 +80,32 @@ The goal of cargo-warden is to provide Rust developers with a secure sandbox for
 
 Components:
 
-* **bpf-core** – eBPF programs (LSM and cgroup) for exec, filesystem, and network.
-* **bpf-api** – shared structures and map layouts with stable ABI.
-* **policy-core** – permission model and config parsing.
-* **policy-compiler** – compiles policies into compact structures for eBPF maps.
-* **agent-lite** – userspace daemon for events, logs, and basic telemetry.
+* **qqrm-bpf-core** – eBPF programs (LSM and cgroup) for exec, filesystem, and network.
+* **qqrm-bpf-api** – shared structures and map layouts with stable ABI.
+* **qqrm-policy-core** – permission model and config parsing.
+* **qqrm-policy-compiler** – compiles policies into compact structures for eBPF maps.
+* **qqrm-agent-lite** – userspace daemon for events, logs, and basic telemetry.
 * **cli** – `cargo-warden` subcommand and wrapper: creates cgroup, loads BPF, handles UX.
-* **testkits** – utilities for integration testing.
+* **qqrm-testkits** – utilities for integration testing.
 * **examples** – demonstration projects with benign and malicious cases.
 
 Boundaries:
 
-* `bpf-core` imports only types from `bpf-api`.
-* `cli` and `agent-lite` contain no business logic—only wiring and output.
-* `policy-core` knows nothing about eBPF, `policy-compiler` knows nothing about the CLI.
+* `qqrm-bpf-core` imports only types from `qqrm-bpf-api`.
+* `cli` and `qqrm-agent-lite` contain no business logic—only wiring and output.
+* `qqrm-policy-core` knows nothing about eBPF, `qqrm-policy-compiler` knows nothing about the CLI.
 
 ## 7. Workspace Layout and Features
 
 Workspace crates:
 
-* `crates/bpf-api`
-* `crates/bpf-core`
-* `crates/policy-core`
-* `crates/policy-compiler`
-* `crates/agent-lite`
+* `crates/qqrm-bpf-api`
+* `crates/qqrm-bpf-core`
+* `crates/qqrm-policy-core`
+* `crates/qqrm-policy-compiler`
+* `crates/qqrm-agent-lite`
 * `crates/cli`
-* `crates/testkits`
+* `crates/qqrm-testkits`
 * `crates/examples/*`
 
 Feature flags:
@@ -117,7 +117,7 @@ Feature flags:
 
 ## 8. Module Contracts
 
-`bpf-api`
+`qqrm-bpf-api`
 
 ```rust
 #[repr(C)]
@@ -133,7 +133,7 @@ pub struct Event {
 }
 ```
 
-`policy-core`
+`qqrm-policy-core`
 
 ```rust
 pub enum Permission {
@@ -147,7 +147,7 @@ pub enum Permission {
 pub struct Policy { pub rules: Vec<Permission>, pub mode: Mode }
 ```
 
-`policy-compiler`
+`qqrm-policy-compiler`
 
 ```rust
 pub struct MapsLayout { /* descriptions for eBPF maps */ }
@@ -155,7 +155,7 @@ pub struct MapsLayout { /* descriptions for eBPF maps */ }
 pub fn compile(policy: &Policy) -> Result<MapsLayout, Error>;
 ```
 
-`agent-lite`
+`qqrm-agent-lite`
 
 ```rust
 pub fn run(layout: &MapsLayout) -> anyhow::Result<Report>;
@@ -249,7 +249,7 @@ User’s local trust database:
 * Launches `cargo` as a child process; the entire process tree inherits the cgroup.
 * Uprobes tag processes and populate eBPF maps with policy IDs.
 * On risky operations eBPF returns Allow or `EPERM`.
-* `agent-lite` reads events from a ring buffer and writes a report.
+* `qqrm-agent-lite` reads events from a ring buffer and writes a report.
 
 ## 12. User Experience and Commands
 
@@ -305,7 +305,7 @@ Levels:
 * Unit tests in each crate.
 * Integration tests in `cli` with examples.
 * Negative tests expect `EPERM` and precise hints.
-* Property-based tests in `policy-compiler` for paths and rules.
+* Property-based tests in `qqrm-policy-compiler` for paths and rules.
 * Fuzzing in config parsers and event handling.
 
 Examples:
@@ -344,7 +344,7 @@ Phased without dates. Each phase has a clear scope, artifacts, and exit criteria
 
 **Artifacts**
 
-* Crates: `bpf-api`, `bpf-core`, `cli`, `agent-lite`, `examples`.
+* Crates: `qqrm-bpf-api`, `qqrm-bpf-core`, `cli`, `qqrm-agent-lite`, `examples`.
 * Text report and JSON events.
 
 **Exit criteria**
@@ -369,7 +369,7 @@ Phased without dates. Each phase has a clear scope, artifacts, and exit criteria
 
 **Artifacts**
 
-* Crates: `policy-core`, `policy-compiler`, updates to `bpf-core` and `cli`.
+* Crates: `qqrm-policy-core`, `qqrm-policy-compiler`, updates to `qqrm-bpf-core` and `cli`.
 * Examples: writing to `$HOME`, `/tmp`, reading secrets.
 
 **Exit criteria**
@@ -392,7 +392,7 @@ Phased without dates. Each phase has a clear scope, artifacts, and exit criteria
 
 **Artifacts**
 
-* Crates: `report-lite` or extension to `agent-lite` for metrics and SARIF export.
+* Crates: `report-lite` or extension to `qqrm-agent-lite` for metrics and SARIF export.
 * `.github/workflows/warden-ci.yml` example.
 
 **Exit criteria**
@@ -409,8 +409,8 @@ Phased without dates. Each phase has a clear scope, artifacts, and exit criteria
 **Scope**
 
 * Performance: CPU ≤ 3%, I/O ≤ 5% on typical projects.
-* Property-based tests for `policy-compiler`, fuzzing parsers.
-* Freeze `bpf-api` ABI and map layout, version compatibility policy.
+* Property-based tests for `qqrm-policy-compiler`, fuzzing parsers.
+* Freeze `qqrm-bpf-api` ABI and map layout, version compatibility policy.
 * Complete `CONTRIBUTING`, `SECURITY`, `CODEOWNERS`.
 
 **Artifacts**
@@ -474,7 +474,7 @@ jobs:
 
 * Rust 2024, `clippy` strict, deny warnings
 * Format with stable `rustfmt`
-* Public API only in `bpf-api` and `policy-core`; everything else `pub(crate)`
+* Public API only in `qqrm-bpf-api` and `qqrm-policy-core`; everything else `pub(crate)`
 
 ### D. Glossary
 

--- a/crates/agent-lite/Cargo.toml
+++ b/crates/agent-lite/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "agent-lite"
+name = "qqrm-agent-lite"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 aya = { version = "0.13" }
-bpf-api = { path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bpf-api"
+name = "qqrm-bpf-api"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/bpf-core/Cargo.toml
+++ b/crates/bpf-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bpf-core"
+name = "qqrm-bpf-core"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -9,13 +9,13 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bpf-api = { path = "../bpf-api", optional = true }
+bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api", optional = true }
 
 [features]
 fuzzing = ["bpf-api"]
 
 [target.'cfg(target_arch = "bpf")'.dependencies]
-bpf-api = { path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
 
 [dev-dependencies]
-bpf-api = { path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo-warden"
+name = "qqrm-cargo-warden"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -8,9 +8,13 @@ license = "MIT OR Apache-2.0"
 clap = { version = "4", features = ["derive"] }
 libseccomp = "0.3"
 libc = "0.2"
-policy-core = { version = "0.1.0", path = "../policy-core" }
+policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+
+[[bin]]
+name = "cargo-warden"
+path = "src/main.rs"

--- a/crates/policy-compiler/Cargo.toml
+++ b/crates/policy-compiler/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "policy-compiler"
+name = "qqrm-policy-compiler"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-policy-core = { path = "../policy-core" }
+policy-core = { package = "qqrm-policy-core", path = "../policy-core" }

--- a/crates/policy-core/Cargo.toml
+++ b/crates/policy-core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "policy-core"
+name = "qqrm-policy-core"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/crates/testkits/Cargo.toml
+++ b/crates/testkits/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "testkits"
+name = "qqrm-testkits"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/examples/network-build/Cargo.toml
+++ b/examples/network-build/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "network-build"
+name = "qqrm-network-build"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/examples/spawn-bash/Cargo.toml
+++ b/examples/spawn-bash/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spawn-bash"
+name = "qqrm-spawn-bash"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -12,30 +12,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bpf-api"
-version = "0.1.0"
-
-[[package]]
-name = "bpf-core"
-version = "0.1.0"
-dependencies = [
- "bpf-api",
-]
-
-[[package]]
 name = "cargo-warden-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "bpf-core",
  "libfuzzer-sys",
+ "qqrm-bpf-core",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -114,6 +103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "qqrm-bpf-api"
+version = "0.1.0"
+
+[[package]]
+name = "qqrm-bpf-core"
+version = "0.1.0"
+dependencies = [
+ "qqrm-bpf-api",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "wasi"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-bpf-core = { path = "../crates/bpf-core", features = ["fuzzing"] }
+bpf-core = { package = "qqrm-bpf-core", path = "../crates/bpf-core", features = ["fuzzing"] }
 
 [[bin]]
 name = "net"

--- a/scripts/build-bpf.sh
+++ b/scripts/build-bpf.sh
@@ -19,7 +19,7 @@ fi
 
 for arch in "${ARCHES[@]}"; do
     RUSTFLAGS="-C link-arg=--llvm-args=-bpf-stack-size=$STACK_SIZE" \
-        cargo +nightly rustc -p bpf-core --release --target "$TARGET" -Z build-std=core -- --emit=obj
+        cargo +nightly rustc -p qqrm-bpf-core --release --target "$TARGET" -Z build-std=core -- --emit=obj
     mkdir -p "prebuilt/$arch"
-    cp "target/$TARGET/release/deps/bpf_core.o" "prebuilt/$arch/bpf-core.o"
+    cp "target/$TARGET/release/deps/qqrm_bpf_core.o" "prebuilt/$arch/qqrm-bpf-core.o"
 done

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Build release binaries for CLI and agent
-cargo build --release -p cargo-warden -p agent-lite
+cargo build --release -p qqrm-cargo-warden -p qqrm-agent-lite
 
 # Determine version from CLI crate
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' crates/cli/Cargo.toml)
@@ -11,9 +11,9 @@ OUTDIR=dist
 mkdir -p "$OUTDIR"
 
 # Choose agent artifact: binary if available, otherwise library
-AGENT_PATH="target/release/agent-lite"
+AGENT_PATH="target/release/qqrm-agent-lite"
 if [[ ! -f "$AGENT_PATH" ]]; then
-    AGENT_PATH="target/release/libagent_lite.rlib"
+    AGENT_PATH="target/release/libqqrm_agent_lite.rlib"
 fi
 
 TARFILE="$OUTDIR/cargo-warden-$VERSION-$ARCH.tar.gz"


### PR DESCRIPTION
## Summary
- prefix internal crates with `qqrm-` to ensure unique names
- update build scripts, Dockerfile, and docs for new crate names

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68c74f3d10608332bf905436303ce47d