### PR TITLE
Publish crates using manifest names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: |
           set -e
-          crates="bpf-api bpf-core policy-core policy-compiler agent-lite testkits cargo-warden"
-          for crate in $crates; do
-            cargo publish -p "$crate" --token "${{ secrets.CRATES_IO_TOKEN }}"
+          crate_dirs="crates/bpf-api crates/bpf-core crates/policy-core crates/policy-compiler crates/agent-lite crates/testkits crates/cli"
+          for dir in $crate_dirs; do
+            name=$(sed -n 's/^name = "\(.*\)"/\1/p' "$dir/Cargo.toml")
+            cargo publish -p "$name" --token "${{ secrets.CRATES_IO_TOKEN }}"
           done

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -42,6 +42,7 @@
 - [x] Publish qqrm-policy-core before qqrm-cargo-warden in release workflow.
 - [x] Fix publish workflow to use CI environment for secrets.
 - [x] Prefix crate names with `qqrm-` to avoid crates.io collisions.
+- [x] Derive crate names from Cargo manifests in publish workflow.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.


### PR DESCRIPTION
## Summary
- derive publish workflow crate names from manifest files
- note roadmap completion for automatic crate name detection

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `actionlint .github/workflows/publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_68c7568fe1148332911187d2294e5bdd