### PR TITLE
Use prod environment for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: CI
+    environment: prod
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- Switch the publish job to use the `prod` environment so the crates.io token is available. (F:.github/workflows/publish.yml#L10-L22)

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68c8ab5d21048332b4223a61deec3d44