### PR TITLE
Ensure workspace crates publish cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           components: rustfmt, clippy, llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+      - run: python3 scripts/check_path_versions.py
       - run: sudo apt-get update && sudo apt-get install -y pkg-config libseccomp-dev protobuf-compiler jq
       - uses: taiki-e/install-action@v2
         with:

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -43,6 +43,7 @@
 - [x] Fix publish workflow to use CI environment for secrets.
 - [x] Prefix crate names with `qqrm-` to avoid crates.io collisions.
 - [x] Derive crate names from Cargo manifests in publish workflow.
+- [x] Add CI guard ensuring path dependencies specify versions for crates.io publishing.
 
 ## Phase 2 Progress
 - [x] Expose control for filesystem read/write policies in BPF API.

--- a/crates/agent-lite/Cargo.toml
+++ b/crates/agent-lite/Cargo.toml
@@ -3,10 +3,15 @@ name = "qqrm-agent-lite"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "User-space agent streaming cargo-warden sandbox telemetry."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-agent-lite"
+readme = "../../README.md"
 
 [dependencies]
 aya = { version = "0.13" }
-bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -3,6 +3,11 @@ name = "qqrm-bpf-api"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Shared eBPF API structures for the cargo-warden sandbox."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-bpf-api"
+readme = "../../README.md"
 
 [lib]
 path = "src/lib.rs"

--- a/crates/bpf-core/Cargo.toml
+++ b/crates/bpf-core/Cargo.toml
@@ -3,19 +3,24 @@ name = "qqrm-bpf-core"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "eBPF enforcement programs for the cargo-warden sandbox."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-bpf-core"
+readme = "../../README.md"
 
 [lib]
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api", optional = true }
+bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api", optional = true }
 
 [features]
 fuzzing = ["bpf-api"]
 
 [target.'cfg(target_arch = "bpf")'.dependencies]
-bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
 
 [dev-dependencies]
-bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,11 @@ name = "qqrm-cargo-warden"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Command-line interface for the cargo-warden sandbox."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-cargo-warden"
+readme = "../../README.md"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/crates/policy-compiler/Cargo.toml
+++ b/crates/policy-compiler/Cargo.toml
@@ -3,6 +3,11 @@ name = "qqrm-policy-compiler"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Compile cargo-warden policies into eBPF-friendly representations."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-policy-compiler"
+readme = "../../README.md"
 
 [dependencies]
-policy-core = { package = "qqrm-policy-core", path = "../policy-core" }
+policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }

--- a/crates/policy-core/Cargo.toml
+++ b/crates/policy-core/Cargo.toml
@@ -3,6 +3,11 @@ name = "qqrm-policy-core"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Policy data model and validation for the cargo-warden sandbox."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-policy-core"
+readme = "../../README.md"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/testkits/Cargo.toml
+++ b/crates/testkits/Cargo.toml
@@ -3,5 +3,10 @@ name = "qqrm-testkits"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "Testing utilities for cargo-warden sandbox components."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/qqrm-testkits"
+readme = "../../README.md"
 
 [dependencies]

--- a/scripts/check_path_versions.py
+++ b/scripts/check_path_versions.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Validate that path dependencies declare versions for publishing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class Problem:
+    manifest: Path
+    dependency: str
+    target: str | None
+    path_value: str
+
+    def format(self) -> str:
+        location = f"{self.manifest.relative_to(ROOT)}"
+        if self.target:
+            location = f"{location} ({self.target})"
+        return (
+            f"{location}: dependency '{self.dependency}' uses path '{self.path_value}' without a version"
+        )
+
+
+def load_workspace_manifests() -> Iterable[Path]:
+    metadata = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    data = json.loads(metadata.stdout)
+    members = set(data["workspace_members"])
+    for package in data["packages"]:
+        if package["id"] in members:
+            yield Path(package["manifest_path"])
+
+
+def check_dependency_table(
+    table: Mapping[str, object],
+    *,
+    manifest: Path,
+    target: str | None,
+    problems: List[Problem],
+) -> None:
+    for name, raw_spec in table.items():
+        if not isinstance(raw_spec, MutableMapping):
+            # Specifications that are strings or numbers cannot contain path dependencies.
+            continue
+        spec = dict(raw_spec)
+        if "path" in spec and "version" not in spec:
+            problems.append(
+                Problem(
+                    manifest=manifest,
+                    dependency=name,
+                    target=target,
+                    path_value=str(spec["path"]),
+                )
+            )
+
+
+def collect_problems(manifest_path: Path) -> List[Problem]:
+    with manifest_path.open("rb") as fh:
+        data = tomllib.load(fh)  # type: ignore[name-defined]
+
+    problems: List[Problem] = []
+    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+        table = data.get(section)
+        if isinstance(table, Mapping):
+            check_dependency_table(
+                table, manifest=manifest_path, target=None, problems=problems
+            )
+
+    target_tables = data.get("target")
+    if isinstance(target_tables, Mapping):
+        for target_name, target_table in target_tables.items():
+            if not isinstance(target_table, Mapping):
+                continue
+            for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+                table = target_table.get(section)
+                if isinstance(table, Mapping):
+                    check_dependency_table(
+                        table,
+                        manifest=manifest_path,
+                        target=target_name,
+                        problems=problems,
+                    )
+
+    return problems
+
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def main() -> int:
+    problems: List[Problem] = []
+    for manifest in load_workspace_manifests():
+        problems.extend(collect_problems(manifest))
+
+    if problems:
+        for problem in problems:
+            print(problem.format(), file=sys.stderr)
+        print(
+            "error: add an explicit version alongside each path dependency", file=sys.stderr
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add metadata to workspace crates and require versioned path dependencies to support publishing (F:crates/agent-lite/Cargo.toml#L1-L44, F:crates/bpf-core/Cargo.toml#L1-L26, F:crates/bpf-api/Cargo.toml#L1-L16, F:crates/cli/Cargo.toml#L1-L25, F:crates/policy-compiler/Cargo.toml#L1-L13, F:crates/policy-core/Cargo.toml#L1-L18, F:crates/testkits/Cargo.toml#L1-L12)
- Document the new safeguard in the Phase 1 roadmap (F:ROADMAP_PHASE1.md#L43-L46)
- Add a CI step that enforces versioned path dependencies with a dedicated checker (F:.github/workflows/ci.yml#L20-L27, F:scripts/check_path_versions.py#L1-L123)

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `actionlint`


------
https://chatgpt.com/codex/tasks/task_e_68c8d211b9ec8332a8e70e9cc928e775