### PR TITLE
Rename workflow jobs for clarity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           reporter: github-check
           github_token: ${{ secrets.GITHUB_TOKEN }}
-  check:
+  cargo-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/warden-ci.yml
+++ b/.github/workflows/warden-ci.yml
@@ -1,7 +1,7 @@
 name: warden-ci
 on: [push, pull_request]
 jobs:
-  build:
+  warden-scan:
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Rename the CI `check` job to `cargo-checks` to reflect the lint, test, and audit steps it runs. (F:.github/workflows/ci.yml#L18-L70)
- Update the warden workflow job identifier to `warden-scan` for clearer intent. (F:.github/workflows/warden-ci.yml#L4-L11)

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68c8e8f1aaa48332b12554bcaabaf179