### PR TITLE
Switch Publish Crates workflow to cargo-workspaces

### DIFF
--- a/.github/workflows/Publish Crates.yml
+++ b/.github/workflows/Publish Crates.yml
@@ -14,10 +14,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: |
-          set -e
-          crate_dirs="crates/bpf-api crates/bpf-core crates/policy-core crates/policy-compiler crates/agent-lite crates/testkits crates/cli"
-          for dir in $crate_dirs; do
-            name=$(sed -n 's/^name = "\(.*\)"/\1/p' "$dir/Cargo.toml")
-            cargo publish -p "$name" --token "${{ secrets.CRATES_IO_TOKEN }}"
-          done
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces --locked
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          set -euo pipefail
+          cargo workspaces publish \
+            --publish-as-is \
+            --no-git-commit \
+            --no-git-tag \
+            --no-git-push \
+            --publish-interval 45 \
+            -y \
+            --package qqrm-bpf-api \
+            --package qqrm-bpf-core \
+            --package qqrm-policy-core \
+            --package qqrm-policy-compiler \
+            --package qqrm-agent-lite \
+            --package qqrm-testkits \
+            --package qqrm-cargo-warden

--- a/examples/network-build/Cargo.toml
+++ b/examples/network-build/Cargo.toml
@@ -3,5 +3,6 @@ name = "qqrm-network-build"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+publish = false
 
 [dependencies]

--- a/examples/spawn-bash/Cargo.toml
+++ b/examples/spawn-bash/Cargo.toml
@@ -3,5 +3,6 @@ name = "qqrm-spawn-bash"
 version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+publish = false
 
 [dependencies]


### PR DESCRIPTION
## Summary
- install the cargo-workspaces tool in the release workflow
- publish workspace crates via `cargo workspaces publish` with delays and dependency ordering
- mark example crates as non-publishable to keep them out of release runs

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68c8ff33fcf08332a05d79b49ba03b51