### PR TITLE
Update SARIF upload action to v3

### DIFF
--- a/warden-ci/README.md
+++ b/warden-ci/README.md
@@ -30,6 +30,6 @@ jobs:
 
 When a pull request triggers this workflow, any violations reported by
 `cargo warden` are exported to `warden.sarif` and uploaded via
-`github/codeql-action/upload-sarif@v2`. GitHub surfaces these findings
+`github/codeql-action/upload-sarif@v3`. GitHub surfaces these findings
 directly on the pull request as inline annotations and under the
 Security tab, making violations easy to spot.

--- a/warden-ci/action.yml
+++ b/warden-ci/action.yml
@@ -27,7 +27,7 @@ runs:
       run: cargo warden report --output warden.sarif
     - name: Upload SARIF report
       if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: warden.sarif
       continue-on-error: true


### PR DESCRIPTION
## Summary
- update the Warden CI composite action to upload SARIF with github/codeql-action/upload-sarif@v3
- refresh the action README to reference the new SARIF uploader version

## Testing
- actionlint
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete


------
https://chatgpt.com/codex/tasks/task_e_68ca9ebb8ec88332b16c01c6345e893d