### PR TITLE
Move cargo geiger to manual workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,9 +46,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-geiger
       - run: cargo fmt --all -- --check
       - run: cargo check --tests --benches
       - run: cargo clippy --all-targets --all-features -- -D warnings
@@ -59,12 +56,6 @@ jobs:
       - run: cargo deny check
       - run: cargo llvm-cov --no-report
       - run: cargo spellcheck --code 1
-        continue-on-error: true
-      - name: cargo geiger
-        run: |
-          for manifest in $(cargo metadata --format-version 1 --no-deps | jq -r '.packages[].manifest_path'); do
-            cargo geiger --manifest-path "$manifest" --all-features --output-format GitHubMarkdown || true
-          done
         continue-on-error: true
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo +nightly udeps --all-targets --all-features

--- a/.github/workflows/cargo-geiger.yml
+++ b/.github/workflows/cargo-geiger.yml
@@ -1,0 +1,23 @@
+name: Cargo Geiger
+
+on:
+  workflow_dispatch:
+
+jobs:
+  geiger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-geiger
+      - name: cargo geiger
+        run: |
+          set -euo pipefail
+          for manifest in $(cargo metadata --format-version 1 --no-deps | jq -r '.packages[].manifest_path'); do
+            cargo geiger --manifest-path "$manifest" --all-features --output-format GitHubMarkdown || true
+          done

--- a/ROADMAP_PHASE1.md
+++ b/ROADMAP_PHASE1.md
@@ -35,6 +35,7 @@
 - [x] Install cargo-deny in CI pipeline for dependency auditing.
 - [x] Plan additional DevSecOps tooling: cargo-audit, cargo-udeps, cargo-llvm-cov, cargo-nextest, cargo-spellcheck, actionlint.
 - [x] Integrate cargo-geiger for unsafe-code analysis.
+- [x] Move cargo-geiger checks into a manual GitHub workflow.
 - [x] Extend property-based test coverage for policy validation.
 - [x] Draft roadmap for Phase 2.
 - [x] Draft roadmap for Phase 3.


### PR DESCRIPTION
## Summary
- Remove cargo-geiger installation from the default CI cargo-checks job to keep the main pipeline lean. F:.github/workflows/CI.yml#L18-L61
- Add a manual cargo-geiger workflow triggered via workflow_dispatch for on-demand unsafe code scans. F:.github/workflows/cargo-geiger.yml#L1-L23
- Mark the roadmap item for moving cargo-geiger checks into a manual workflow as complete. F:ROADMAP_PHASE1.md#L30-L47

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68ca9f1e59288332a3f480f44c6ee7d4