### PR TITLE
Handle non-string path values in version check script

### DIFF
--- a/scripts/check_path_versions.rs
+++ b/scripts/check_path_versions.rs
@@ -148,6 +148,8 @@ fn check_dependency_table(
 fn value_to_string(value: &Value) -> String {
     match value {
         Value::String(s) => s.clone(),
-        other => other.to_string(),
-   }
+        other => toml::to_string(other)
+            .map(|s| s.trim().to_owned())
+            .unwrap_or_else(|_| format!("{other:?}")),
+    }
 }


### PR DESCRIPTION
## Summary
- serialize non-string TOML values when rendering path dependency descriptions to avoid missing Display impls `F:scripts/check_path_versions.rs#L148-L153`

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68caef246cb083328c0aba2073713d3f