### PR TITLE
Refactor BPF maps to use aya definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya-ebpf"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dbaf5409a1a0982e5c9bdc0f499a55fe5ead39fe9c846012053faf0d404f73"
+dependencies = [
+ "aya-ebpf-bindings",
+ "aya-ebpf-cty",
+ "aya-ebpf-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "aya-ebpf-bindings"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783dc1a82a3d71d83286165381dcc1b1d41643f4b110733d135547527c000a9a"
+dependencies = [
+ "aya-ebpf-cty",
+]
+
+[[package]]
+name = "aya-ebpf-cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cce099aaf3abb89f9a1f8594ffe07fa53738ebc2882fac624d10d9ba31a1b10"
+
+[[package]]
+name = "aya-ebpf-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f47f7b4a75eb5f1d7ba0fb5628d247b1cf20388658899177875dabdda66865"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "aya-obj"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +938,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1048,6 +1110,7 @@ version = "0.1.0"
 name = "qqrm-bpf-core"
 version = "0.1.0"
 dependencies = [
+ "aya-ebpf",
  "qqrm-bpf-api",
 ]
 

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -5,6 +5,17 @@ pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
 pub const FS_WRITE: u8 = 2;
 
+/// Maximum number of exec allowlist entries supported by the eBPF map.
+pub const EXEC_ALLOWLIST_CAPACITY: u32 = 64;
+/// Maximum number of network rules supported by the eBPF map.
+pub const NET_RULES_CAPACITY: u32 = 256;
+/// Maximum number of parent relationships supported by the eBPF map.
+pub const NET_PARENTS_CAPACITY: u32 = 256;
+/// Size of the event ring buffer in bytes.
+pub const EVENT_RINGBUF_CAPACITY_BYTES: u32 = 4096;
+/// Number of slots tracked for emitted event counters.
+pub const EVENT_COUNT_SLOTS: u32 = 1;
+
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct ExecAllowEntry {

--- a/crates/bpf-core/Cargo.toml
+++ b/crates/bpf-core/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+aya-bpf = { package = "aya-ebpf", version = "0.1.1" }
 bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api", optional = true }
 
 [features]

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -1,8 +1,15 @@
 #![cfg_attr(target_arch = "bpf", no_std)]
 #![cfg_attr(not(target_arch = "bpf"), allow(dead_code))]
 
+#[cfg(target_arch = "bpf")]
+use aya_bpf::{
+    macros::map,
+    maps::{Array, RingBuf},
+};
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-use bpf_api::Event;
+use bpf_api::{self, Event};
+#[cfg(any(test, feature = "fuzzing"))]
+use core::cell::UnsafeCell;
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
 use core::{ffi::c_void, mem::size_of};
 
@@ -23,11 +30,283 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
+#[cfg(any(test, feature = "fuzzing"))]
+struct TestArray<T: Copy, const N: usize> {
+    data: UnsafeCell<[Option<T>; N]>,
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+unsafe impl<T: Copy, const N: usize> Sync for TestArray<T, N> {}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl<T: Copy, const N: usize> TestArray<T, N> {
+    const fn new() -> Self {
+        Self {
+            data: UnsafeCell::new([None; N]),
+        }
+    }
+
+    fn get(&self, index: u32) -> Option<T> {
+        let idx = index as usize;
+        if idx >= N {
+            return None;
+        }
+        unsafe { (*self.data.get())[idx] }
+    }
+
+    fn set(&self, index: u32, value: T) {
+        let idx = index as usize;
+        if idx >= N {
+            return;
+        }
+        unsafe {
+            (*self.data.get())[idx] = Some(value);
+        }
+    }
+
+    fn clear(&self) {
+        unsafe {
+            for slot in (*self.data.get()).iter_mut() {
+                *slot = None;
+            }
+        }
+    }
+}
+
 #[cfg(target_arch = "bpf")]
-#[unsafe(no_mangle)]
-#[unsafe(link_section = "maps/exec_allowlist")]
-pub static mut EXEC_ALLOWLIST: [bpf_api::ExecAllowEntry; 1] =
-    [bpf_api::ExecAllowEntry { path: [0; 256] }];
+type ExecAllowlistMap = Array<bpf_api::ExecAllowEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type ExecAllowlistMap =
+    TestArray<bpf_api::ExecAllowEntry, { bpf_api::EXEC_ALLOWLIST_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type NetRulesMap = Array<bpf_api::NetRuleEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type NetRulesMap = TestArray<bpf_api::NetRuleEntry, { bpf_api::NET_RULES_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type NetParentsMap = Array<bpf_api::NetParentEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type NetParentsMap = TestArray<bpf_api::NetParentEntry, { bpf_api::NET_PARENTS_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type LengthMap = Array<u32>;
+#[cfg(any(test, feature = "fuzzing"))]
+type LengthMap = TestArray<u32, 1>;
+
+#[cfg(target_arch = "bpf")]
+type EventCountsMap = Array<u64>;
+#[cfg(any(test, feature = "fuzzing"))]
+type EventCountsMap = TestArray<u64, { bpf_api::EVENT_COUNT_SLOTS as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type EventsMap = RingBuf;
+#[cfg(any(test, feature = "fuzzing"))]
+#[derive(Copy, Clone)]
+struct DummyRingBuf;
+#[cfg(any(test, feature = "fuzzing"))]
+type EventsMap = DummyRingBuf;
+
+#[cfg(target_arch = "bpf")]
+const fn exec_allowlist_map() -> ExecAllowlistMap {
+    Array::with_max_entries(bpf_api::EXEC_ALLOWLIST_CAPACITY, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn exec_allowlist_map() -> ExecAllowlistMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
+const fn net_rules_map() -> NetRulesMap {
+    Array::with_max_entries(bpf_api::NET_RULES_CAPACITY, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn net_rules_map() -> NetRulesMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
+const fn net_parents_map() -> NetParentsMap {
+    Array::with_max_entries(bpf_api::NET_PARENTS_CAPACITY, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn net_parents_map() -> NetParentsMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
+const fn length_map() -> LengthMap {
+    Array::with_max_entries(1, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn length_map() -> LengthMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
+const fn events_map() -> EventsMap {
+    RingBuf::with_byte_size(bpf_api::EVENT_RINGBUF_CAPACITY_BYTES, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn events_map() -> EventsMap {
+    DummyRingBuf
+}
+
+#[cfg(target_arch = "bpf")]
+const fn event_counts_map() -> EventCountsMap {
+    Array::with_max_entries(bpf_api::EVENT_COUNT_SLOTS, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn event_counts_map() -> EventCountsMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EXEC_ALLOWLIST")]
+static mut EXEC_ALLOWLIST: ExecAllowlistMap = exec_allowlist_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EXEC_ALLOWLIST: ExecAllowlistMap = exec_allowlist_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EXEC_ALLOWLIST_LENGTH")]
+static mut EXEC_ALLOWLIST_LENGTH: LengthMap = length_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EXEC_ALLOWLIST_LENGTH: LengthMap = length_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_RULES")]
+static mut NET_RULES: NetRulesMap = net_rules_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_RULES: NetRulesMap = net_rules_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_RULES_LENGTH")]
+static mut NET_RULES_LENGTH: LengthMap = length_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_RULES_LENGTH: LengthMap = length_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_PARENTS")]
+static mut NET_PARENTS: NetParentsMap = net_parents_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_PARENTS: NetParentsMap = net_parents_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_PARENTS_LENGTH")]
+static mut NET_PARENTS_LENGTH: LengthMap = length_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_PARENTS_LENGTH: LengthMap = length_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EVENTS")]
+static mut EVENTS: EventsMap = events_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EVENTS: EventsMap = events_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EVENT_COUNTS")]
+static mut EVENT_COUNTS: EventCountsMap = event_counts_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EVENT_COUNTS: EventCountsMap = event_counts_map();
+
+#[cfg(target_arch = "bpf")]
+unsafe fn load_exec_allow_entry(index: u32) -> Option<bpf_api::ExecAllowEntry> {
+    EXEC_ALLOWLIST.get(index).copied()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+unsafe fn load_exec_allow_entry(index: u32) -> Option<bpf_api::ExecAllowEntry> {
+    EXEC_ALLOWLIST.get(index)
+}
+
+#[cfg(target_arch = "bpf")]
+unsafe fn load_net_rule(index: u32) -> Option<bpf_api::NetRuleEntry> {
+    NET_RULES.get(index).copied()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+unsafe fn load_net_rule(index: u32) -> Option<bpf_api::NetRuleEntry> {
+    NET_RULES.get(index)
+}
+
+#[cfg(target_arch = "bpf")]
+unsafe fn load_net_parent(index: u32) -> Option<bpf_api::NetParentEntry> {
+    NET_PARENTS.get(index).copied()
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+unsafe fn load_net_parent(index: u32) -> Option<bpf_api::NetParentEntry> {
+    NET_PARENTS.get(index)
+}
+
+#[cfg(target_arch = "bpf")]
+unsafe fn load_length(map: &LengthMap) -> u32 {
+    map.get(0).copied().unwrap_or(0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+unsafe fn load_length(map: &LengthMap) -> u32 {
+    map.get(0).unwrap_or(0)
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn clamp_len(len: u32, capacity: u32) -> u32 {
+    len.min(capacity)
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn exec_allowlist_len() -> u32 {
+    clamp_len(
+        unsafe { load_length(&EXEC_ALLOWLIST_LENGTH) },
+        bpf_api::EXEC_ALLOWLIST_CAPACITY,
+    )
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn net_rules_len() -> u32 {
+    clamp_len(
+        unsafe { load_length(&NET_RULES_LENGTH) },
+        bpf_api::NET_RULES_CAPACITY,
+    )
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn net_parents_len() -> u32 {
+    clamp_len(
+        unsafe { load_length(&NET_PARENTS_LENGTH) },
+        bpf_api::NET_PARENTS_CAPACITY,
+    )
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn increment_event_count() {
+    #[cfg(target_arch = "bpf")]
+    unsafe {
+        if let Some(counter) = EVENT_COUNTS.get_ptr_mut(0) {
+            *counter = counter.wrapping_add(1);
+        }
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    {
+        let current = EVENT_COUNTS.get(0).unwrap_or(0);
+        EVENT_COUNTS.set(0, current.wrapping_add(1));
+    }
+}
 
 #[cfg(target_arch = "bpf")]
 fn path_matches(a: &[u8; 256], b: &[u8; 256]) -> bool {
@@ -43,27 +322,6 @@ fn path_matches(a: &[u8; 256], b: &[u8; 256]) -> bool {
     }
     true
 }
-
-#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-#[unsafe(no_mangle)]
-#[unsafe(link_section = "maps/net_rules")]
-pub static mut NET_RULES: [bpf_api::NetRuleEntry; 1] = [bpf_api::NetRuleEntry {
-    unit: 0,
-    rule: bpf_api::NetRule {
-        addr: [0; 16],
-        protocol: 0,
-        prefix_len: 0,
-        port: 0,
-    },
-}];
-
-#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-#[unsafe(no_mangle)]
-#[unsafe(link_section = "maps/net_parents")]
-pub static mut NET_PARENTS: [bpf_api::NetParentEntry; 1] = [bpf_api::NetParentEntry {
-    child: 0,
-    parent: 0,
-}];
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
 static mut CURRENT_UNIT: u32 = 0;
@@ -99,19 +357,19 @@ fn rule_matches(rule: &bpf_api::NetRule, addr: &[u8; 16], port: u16, protocol: u
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
 fn get_parent(unit: u32) -> Option<u32> {
-    unsafe {
-        let mut i = 0;
-        while i < 1 {
-            let entry = core::ptr::read(core::ptr::addr_of!(NET_PARENTS[i]));
-            if entry.child == unit {
-                if entry.parent != unit {
-                    return Some(entry.parent);
-                } else {
-                    return None;
-                }
+    let len = net_parents_len();
+    let mut i = 0;
+    while i < len {
+        if let Some(entry) = unsafe { load_net_parent(i) }
+            && entry.child == unit
+        {
+            if entry.parent != unit {
+                return Some(entry.parent);
+            } else {
+                return None;
             }
-            i += 1;
         }
+        i += 1;
     }
     None
 }
@@ -120,15 +378,16 @@ fn get_parent(unit: u32) -> Option<u32> {
 fn net_allowed(addr: &[u8; 16], port: u16, protocol: u8) -> bool {
     let mut unit = current_unit();
     loop {
-        unsafe {
-            let mut i = 0;
-            while i < 1 {
-                let entry = core::ptr::read(core::ptr::addr_of!(NET_RULES[i]));
-                if entry.unit == unit && rule_matches(&entry.rule, addr, port, protocol) {
-                    return true;
-                }
-                i += 1;
+        let len = net_rules_len();
+        let mut i = 0;
+        while i < len {
+            if let Some(entry) = unsafe { load_net_rule(i) }
+                && entry.unit == unit
+                && rule_matches(&entry.rule, addr, port, protocol)
+            {
+                return true;
             }
+            i += 1;
         }
         match get_parent(unit) {
             Some(p) => unit = p,
@@ -193,36 +452,26 @@ pub fn resolve_host(host: &str) -> std::io::Result<Vec<std::net::IpAddr>> {
         .map(|iter| iter.map(|s| s.ip()).collect())
 }
 
-#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-#[unsafe(no_mangle)]
-#[unsafe(link_section = "maps/events")]
-pub static mut EVENTS: [u8; 0] = [];
-
-#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-#[unsafe(no_mangle)]
-#[unsafe(link_section = "maps/event_counts")]
-pub static mut EVENT_COUNTS: [u64; 1] = [0];
-
 #[cfg(target_arch = "bpf")]
 #[unsafe(no_mangle)]
 #[unsafe(link_section = "lsm/bprm_check_security")]
 pub extern "C" fn bprm_check_security(ctx: *mut c_void) -> i32 {
     let filename_ptr = unsafe { *(ctx as *const *const u8) };
     let mut buf = [0u8; 256];
-    unsafe {
-        if bpf_probe_read_user_str(buf.as_mut_ptr(), buf.len() as u32, filename_ptr) < 0 {
-            return deny();
-        }
-        let mut i = 0;
-        while i < 1 {
-            let entry = core::ptr::read(core::ptr::addr_of!(EXEC_ALLOWLIST[i]));
+    if unsafe { bpf_probe_read_user_str(buf.as_mut_ptr(), buf.len() as u32, filename_ptr) } < 0 {
+        return deny();
+    }
+    let len = exec_allowlist_len();
+    let mut i = 0;
+    while i < len {
+        if let Some(entry) = unsafe { load_exec_allow_entry(i) } {
             if path_matches(&entry.path, &buf) {
                 return 0;
             }
-            i += 1;
         }
-        deny()
+        i += 1;
     }
+    deny()
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
@@ -267,15 +516,26 @@ pub extern "C" fn file_open(_file: *mut c_void, _cred: *mut c_void) -> i32 {
         caps: 0,
         path_or_addr: [0; 256],
     };
+    let ringbuf_ptr = {
+        #[cfg(target_arch = "bpf")]
+        {
+            core::ptr::addr_of_mut!(EVENTS) as *mut c_void
+        }
+
+        #[cfg(any(test, feature = "fuzzing"))]
+        {
+            core::ptr::addr_of!(EVENTS) as *const _ as *mut c_void
+        }
+    };
     unsafe {
         bpf_ringbuf_output(
-            core::ptr::addr_of_mut!(EVENTS) as *mut c_void,
+            ringbuf_ptr,
             &event as *const _ as *const c_void,
             size_of::<Event>() as u64,
             0,
         );
-        EVENT_COUNTS[0] += 1;
     }
+    increment_event_count();
     0
 }
 
@@ -330,9 +590,8 @@ mod tests {
 
     #[test]
     fn file_open_emits_event() {
-        unsafe {
-            EVENT_COUNTS[0] = 0;
-        }
+        let _g = TEST_LOCK.lock().unwrap();
+        EVENT_COUNTS.clear();
         file_open(ptr::null_mut(), ptr::null_mut());
         let event = LAST_EVENT.lock().unwrap().expect("event");
         assert_eq!(event.pid, 1234);
@@ -340,9 +599,8 @@ mod tests {
         assert_eq!(event.action, 0);
         assert_eq!(event.verdict, 0);
         assert_eq!(event.path_or_addr[0], 0);
-        unsafe {
-            assert_eq!(EVENT_COUNTS[0], 1);
-        }
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
+        assert_eq!(count, 1);
     }
 
     #[test]
@@ -356,7 +614,12 @@ mod tests {
         assert_ne!(inode_unlink(ptr::null_mut(), ptr::null_mut()), 0);
     }
 
-    fn set_rule(addr: std::net::IpAddr, port: u16, proto: u8) {
+    fn rule_entry(
+        unit: u32,
+        addr: std::net::IpAddr,
+        port: u16,
+        proto: u8,
+    ) -> bpf_api::NetRuleEntry {
         let mut bytes = [0u8; 16];
         let prefix = match addr {
             std::net::IpAddr::V4(v4) => {
@@ -368,35 +631,76 @@ mod tests {
                 128
             }
         };
-        unsafe {
-            NET_RULES[0] = bpf_api::NetRuleEntry {
-                unit: 0,
-                rule: bpf_api::NetRule {
-                    addr: bytes,
-                    protocol: proto,
-                    prefix_len: prefix,
-                    port,
-                },
-            };
+        bpf_api::NetRuleEntry {
+            unit,
+            rule: bpf_api::NetRule {
+                addr: bytes,
+                protocol: proto,
+                prefix_len: prefix,
+                port,
+            },
         }
     }
 
-    fn set_parent(child: u32, parent: u32) {
-        unsafe {
-            NET_PARENTS[0] = bpf_api::NetParentEntry { child, parent };
+    fn set_net_rules(entries: &[bpf_api::NetRuleEntry]) {
+        NET_RULES.clear();
+        NET_RULES_LENGTH.clear();
+        for (idx, entry) in entries.iter().enumerate() {
+            NET_RULES.set(idx as u32, *entry);
         }
+        NET_RULES_LENGTH.set(0, entries.len() as u32);
+    }
+
+    fn set_net_parents(entries: &[bpf_api::NetParentEntry]) {
+        NET_PARENTS.clear();
+        NET_PARENTS_LENGTH.clear();
+        for (idx, entry) in entries.iter().enumerate() {
+            NET_PARENTS.set(idx as u32, *entry);
+        }
+        NET_PARENTS_LENGTH.set(0, entries.len() as u32);
+    }
+
+    fn reset_network_state() {
+        NET_RULES.clear();
+        NET_RULES_LENGTH.clear();
+        NET_PARENTS.clear();
+        NET_PARENTS_LENGTH.clear();
+        unsafe {
+            CURRENT_UNIT = 0;
+        }
+    }
+
+    fn ipv6_words(addr: std::net::Ipv6Addr) -> [u32; 4] {
+        let octets = addr.octets();
+        let mut words = [0u32; 4];
+        for (i, chunk) in octets.chunks_exact(4).enumerate() {
+            words[i] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        words
     }
 
     #[test]
     fn connect4_respects_rules() {
         let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
         let ip = resolve_host("localhost")
             .unwrap()
             .into_iter()
             .find(|i| i.is_ipv4())
             .unwrap();
-        set_rule(ip, 80, 6);
-        set_parent(1, 0);
+        let fallback = std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 1));
+        set_net_rules(&[rule_entry(1, fallback, 80, 6), rule_entry(1, ip, 80, 6)]);
+        set_net_parents(&[
+            bpf_api::NetParentEntry {
+                child: 1,
+                parent: 0,
+            },
+            bpf_api::NetParentEntry {
+                child: 2,
+                parent: 1,
+            },
+        ]);
+        let denied_ip = std::net::IpAddr::V4(std::net::Ipv4Addr::new(198, 51, 100, 1));
         let allowed = SockAddr {
             user_ip4: match ip {
                 std::net::IpAddr::V4(v4) => u32::from_be_bytes(v4.octets()),
@@ -408,7 +712,10 @@ mod tests {
             protocol: 6,
         };
         let other = SockAddr {
-            user_ip4: u32::from_be_bytes([1, 1, 1, 1]),
+            user_ip4: match denied_ip {
+                std::net::IpAddr::V4(v4) => u32::from_be_bytes(v4.octets()),
+                _ => 0,
+            },
             user_ip6: [0; 4],
             user_port: 80u16.to_be(),
             family: 2,
@@ -424,6 +731,12 @@ mod tests {
         unsafe {
             CURRENT_UNIT = 2;
         }
+        assert_eq!(connect4(&allowed as *const _ as *mut c_void), 0);
+        assert_eq!(sendmsg4(&allowed as *const _ as *mut c_void), 0);
+        assert_ne!(connect4(&other as *const _ as *mut c_void), 0);
+        unsafe {
+            CURRENT_UNIT = 3;
+        }
         assert_ne!(connect4(&allowed as *const _ as *mut c_void), 0);
         assert_ne!(sendmsg4(&allowed as *const _ as *mut c_void), 0);
     }
@@ -431,24 +744,31 @@ mod tests {
     #[test]
     fn connect6_respects_rules() {
         let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
         let ip = resolve_host("localhost")
             .unwrap()
             .into_iter()
             .find(|i| i.is_ipv6())
             .unwrap();
-        set_rule(ip, 80, 6);
-        set_parent(1, 0);
+        let fallback = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        set_net_rules(&[
+            rule_entry(1, std::net::IpAddr::V6(fallback), 80, 6),
+            rule_entry(1, ip, 80, 6),
+        ]);
+        set_net_parents(&[
+            bpf_api::NetParentEntry {
+                child: 1,
+                parent: 0,
+            },
+            bpf_api::NetParentEntry {
+                child: 2,
+                parent: 1,
+            },
+        ]);
+        let denied = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2);
         let mut ip6_words = [0u32; 4];
         if let std::net::IpAddr::V6(v6) = ip {
-            let octets = v6.octets();
-            for i in 0..4 {
-                ip6_words[i] = u32::from_be_bytes([
-                    octets[i * 4],
-                    octets[i * 4 + 1],
-                    octets[i * 4 + 2],
-                    octets[i * 4 + 3],
-                ]);
-            }
+            ip6_words = ipv6_words(v6);
         }
         let allowed = SockAddr {
             user_ip4: 0,
@@ -459,7 +779,7 @@ mod tests {
         };
         let other = SockAddr {
             user_ip4: 0,
-            user_ip6: [0; 4],
+            user_ip6: ipv6_words(denied),
             user_port: 80u16.to_be(),
             family: 10,
             protocol: 6,
@@ -473,6 +793,12 @@ mod tests {
         assert_ne!(sendmsg6(&other as *const _ as *mut c_void), 0);
         unsafe {
             CURRENT_UNIT = 2;
+        }
+        assert_eq!(connect6(&allowed as *const _ as *mut c_void), 0);
+        assert_eq!(sendmsg6(&allowed as *const _ as *mut c_void), 0);
+        assert_ne!(connect6(&other as *const _ as *mut c_void), 0);
+        unsafe {
+            CURRENT_UNIT = 3;
         }
         assert_ne!(connect6(&allowed as *const _ as *mut c_void), 0);
         assert_ne!(sendmsg6(&allowed as *const _ as *mut c_void), 0);


### PR DESCRIPTION
## Summary
- expose eBPF map capacities in `bpf-api`
- instantiate `aya` maps in `bpf-core` with host-side test harness helpers
- expand network rule tests to cover parent inheritance and multiple entries

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cb76ce621883329d92aff51791a686