### PR TITLE
Integrate sandbox execution and agent lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +280,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +371,18 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -889,6 +928,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,9 +1121,13 @@ dependencies = [
 name = "qqrm-cargo-warden"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "aya",
  "clap",
  "libc",
  "libseccomp",
+ "qqrm-agent-lite",
  "qqrm-policy-core",
  "serde",
  "serde_json",
@@ -1427,6 +1497,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,14 +10,18 @@ documentation = "https://docs.rs/qqrm-cargo-warden"
 readme = "../../README.md"
 
 [dependencies]
+anyhow = "1"
+aya = "0.13"
 clap = { version = "4", features = ["derive"] }
 libseccomp = "0.3"
 libc = "0.2"
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+qqrm-agent-lite = { path = "../agent-lite" }
 
 [dev-dependencies]
+assert_cmd = "2"
 tempfile = "3"
 
 [[bin]]

--- a/crates/cli/src/sandbox.rs
+++ b/crates/cli/src/sandbox.rs
@@ -1,0 +1,456 @@
+use crate::apply_seccomp;
+use anyhow::Error as AnyhowError;
+use aya::maps::{MapData, ring_buf::RingBuf};
+use aya::programs::cgroup_sock_addr::CgroupSockAddrLink;
+use aya::programs::lsm::LsmLink;
+use aya::programs::{CgroupAttachMode, CgroupSockAddr, Lsm};
+use aya::{Btf, Ebpf, EbpfLoader};
+use qqrm_agent_lite::{self, Config as AgentConfig, Shutdown, ShutdownHandle};
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::{self, Command, ExitStatus};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Wrapper responsible for BPF setup, agent management and cleanup.
+pub(crate) struct Sandbox {
+    inner: SandboxImpl,
+}
+
+enum SandboxImpl {
+    Real(RealSandbox),
+    Fake(FakeSandbox),
+}
+
+impl Sandbox {
+    pub(crate) fn new() -> io::Result<Self> {
+        if env::var_os("QQRM_WARDEN_FAKE_SANDBOX").is_some() {
+            return Ok(Self {
+                inner: SandboxImpl::Fake(FakeSandbox::new()?),
+            });
+        }
+        Ok(Self {
+            inner: SandboxImpl::Real(RealSandbox::new()?),
+        })
+    }
+
+    pub(crate) fn run(&mut self, command: Command, deny: &[String]) -> io::Result<ExitStatus> {
+        match &mut self.inner {
+            SandboxImpl::Real(real) => real.run(command, deny),
+            SandboxImpl::Fake(fake) => fake.run(command),
+        }
+    }
+
+    pub(crate) fn shutdown(self) -> io::Result<()> {
+        match self.inner {
+            SandboxImpl::Real(real) => real.shutdown(),
+            SandboxImpl::Fake(fake) => fake.shutdown(),
+        }
+    }
+}
+
+struct RealSandbox {
+    bpf: Ebpf,
+    cgroup: Cgroup,
+    lsm_links: Vec<LsmLink>,
+    cgroup_links: Vec<CgroupSockAddrLink>,
+    agent: Option<AgentHandle>,
+    events_path: PathBuf,
+}
+
+impl RealSandbox {
+    fn new() -> io::Result<Self> {
+        let events_path = events_path();
+        if let Some(parent) = events_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let bpf = load_bpf()?;
+        let cgroup = Cgroup::create()?;
+        let mut sandbox = RealSandbox {
+            bpf,
+            cgroup,
+            lsm_links: Vec::new(),
+            cgroup_links: Vec::new(),
+            agent: None,
+            events_path,
+        };
+        sandbox.attach_lsm()?;
+        sandbox.attach_cgroup()?;
+        let ring = take_events_ring(&mut sandbox.bpf)?;
+        sandbox.agent = Some(start_agent(ring, sandbox.events_path.clone())?);
+        Ok(sandbox)
+    }
+
+    fn attach_lsm(&mut self) -> io::Result<()> {
+        let btf = Btf::from_sys_fs().map_err(io::Error::other)?;
+        for hook in [
+            "bprm_check_security",
+            "file_open",
+            "file_permission",
+            "inode_unlink",
+        ] {
+            let program = self
+                .bpf
+                .program_mut(hook)
+                .ok_or_else(|| program_not_found(hook))?;
+            let program: &mut Lsm = program
+                .try_into()
+                .map_err(|err| io::Error::other(format!("program {hook} type mismatch: {err}")))?;
+            program
+                .load(hook, &btf)
+                .map_err(|err| io::Error::other(format!("load {hook}: {err}")))?;
+            let link_id = program
+                .attach()
+                .map_err(|err| io::Error::other(format!("attach {hook}: {err}")))?;
+            let link = program
+                .take_link(link_id)
+                .map_err(|err| io::Error::other(format!("link {hook}: {err}")))?;
+            self.lsm_links.push(link);
+        }
+        Ok(())
+    }
+
+    fn attach_cgroup(&mut self) -> io::Result<()> {
+        let dir = self.cgroup.dir_file()?;
+        for name in ["connect4", "connect6", "sendmsg4", "sendmsg6"] {
+            let program = self
+                .bpf
+                .program_mut(name)
+                .ok_or_else(|| program_not_found(name))?;
+            let program: &mut CgroupSockAddr = program
+                .try_into()
+                .map_err(|err| io::Error::other(format!("program {name} type mismatch: {err}")))?;
+            program
+                .load()
+                .map_err(|err| io::Error::other(format!("load {name}: {err}")))?;
+            let link_id = program
+                .attach(dir, CgroupAttachMode::Single)
+                .map_err(|err| io::Error::other(format!("attach {name}: {err}")))?;
+            let link = program
+                .take_link(link_id)
+                .map_err(|err| io::Error::other(format!("link {name}: {err}")))?;
+            self.cgroup_links.push(link);
+        }
+        Ok(())
+    }
+
+    fn run(&self, command: Command, deny: &[String]) -> io::Result<ExitStatus> {
+        let mut command = command;
+        self.install_pre_exec(&mut command, deny)?;
+        let mut child = command.spawn()?;
+        child.wait()
+    }
+
+    fn install_pre_exec(&self, cmd: &mut Command, deny: &[String]) -> io::Result<()> {
+        let procs_fd = self.cgroup.procs_fd_raw()?;
+        let rules = deny.to_vec();
+        unsafe {
+            cmd.pre_exec(move || {
+                join_cgroup_fd(procs_fd)?;
+                if !rules.is_empty() {
+                    apply_seccomp(&rules)?;
+                }
+                Ok(())
+            });
+        }
+        Ok(())
+    }
+
+    fn shutdown(mut self) -> io::Result<()> {
+        if let Some(agent) = self.agent.take() {
+            agent.stop()?;
+        }
+        self.cgroup.cleanup()?;
+        Ok(())
+    }
+}
+
+struct AgentHandle {
+    shutdown: ShutdownHandle,
+    thread: Option<thread::JoinHandle<Result<(), AnyhowError>>>,
+}
+
+impl AgentHandle {
+    fn stop(mut self) -> io::Result<()> {
+        self.shutdown.request();
+        if let Some(handle) = self.thread.take() {
+            match handle.join() {
+                Ok(result) => result.map_err(|err| io::Error::other(err.to_string())),
+                Err(err) => Err(io::Error::other(format!("agent thread panicked: {err:?}"))),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for AgentHandle {
+    fn drop(&mut self) {
+        if let Some(handle) = self.thread.take() {
+            self.shutdown.request();
+            let _ = handle.join();
+        }
+    }
+}
+
+struct Cgroup {
+    path: PathBuf,
+    dir: Option<File>,
+    procs: Option<File>,
+}
+
+impl Cgroup {
+    fn create() -> io::Result<Self> {
+        let base = env::var_os("QQRM_WARDEN_CGROUP_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/sys/fs/cgroup"));
+        let prefix = base.join("cargo-warden");
+        fs::create_dir_all(&prefix)?;
+        let identifier = format!("pid-{}-{}", process::id(), unique_suffix());
+        let path = prefix.join(identifier);
+        fs::create_dir(&path)?;
+        let dir = File::open(&path)?;
+        let procs = OpenOptions::new()
+            .write(true)
+            .open(path.join("cgroup.procs"))?;
+        Ok(Self {
+            path,
+            dir: Some(dir),
+            procs: Some(procs),
+        })
+    }
+
+    fn dir_file(&self) -> io::Result<&File> {
+        self.dir
+            .as_ref()
+            .ok_or_else(|| io::Error::other("cgroup directory handle missing"))
+    }
+
+    fn procs_fd_raw(&self) -> io::Result<RawFd> {
+        self.procs
+            .as_ref()
+            .map(|f| f.as_raw_fd())
+            .ok_or_else(|| io::Error::other("cgroup procs handle missing"))
+    }
+
+    fn cleanup(&mut self) -> io::Result<()> {
+        self.procs.take();
+        self.dir.take();
+        match fs::remove_dir(&self.path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl Drop for Cgroup {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+struct FakeSandbox {
+    cgroup_dir: PathBuf,
+    agent: Option<FakeAgent>,
+}
+
+impl FakeSandbox {
+    fn new() -> io::Result<Self> {
+        let events = events_path();
+        if let Some(parent) = events.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let cgroup_dir = fake_cgroup_dir();
+        if let Some(parent) = cgroup_dir.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::create_dir_all(&cgroup_dir)?;
+        let agent = FakeAgent::spawn(events)?;
+        Ok(Self {
+            cgroup_dir,
+            agent: Some(agent),
+        })
+    }
+
+    fn run(&mut self, mut command: Command) -> io::Result<ExitStatus> {
+        command.status()
+    }
+
+    fn shutdown(mut self) -> io::Result<()> {
+        if let Some(agent) = self.agent.take() {
+            agent.stop()?;
+        }
+        if self.cgroup_dir.exists() {
+            fs::remove_dir_all(&self.cgroup_dir)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for FakeSandbox {
+    fn drop(&mut self) {
+        if let Some(agent) = self.agent.take() {
+            let _ = agent.stop();
+        }
+        if self.cgroup_dir.exists() {
+            let _ = fs::remove_dir_all(&self.cgroup_dir);
+        }
+    }
+}
+
+struct FakeAgent {
+    stop: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<io::Result<()>>>,
+}
+
+impl FakeAgent {
+    fn spawn(path: PathBuf) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_thread = stop.clone();
+        let handle = thread::Builder::new()
+            .name("fake-agent-lite".into())
+            .spawn(move || {
+                while !stop_thread.load(Ordering::SeqCst) {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+                writeln!(file, "{{\"fake\":true}}")?;
+                Ok(())
+            })
+            .map_err(|err| io::Error::other(format!("failed to spawn fake agent: {err}")))?;
+        Ok(Self {
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    fn stop(mut self) -> io::Result<()> {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            match handle.join() {
+                Ok(result) => result,
+                Err(err) => Err(io::Error::other(format!("fake agent panicked: {err:?}"))),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for FakeAgent {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn load_bpf() -> io::Result<Ebpf> {
+    let path = bpf_object_path();
+    let data = fs::read(&path)?;
+    EbpfLoader::new().load(&data).map_err(|err| {
+        io::Error::other(format!(
+            "failed to load BPF object {}: {err}",
+            path.display()
+        ))
+    })
+}
+
+fn bpf_object_path() -> PathBuf {
+    if let Some(path) = env::var_os("QQRM_BPF_OBJECT") {
+        PathBuf::from(path)
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../prebuilt")
+            .join(env::consts::ARCH)
+            .join("qqrm-bpf-core.o")
+    }
+}
+
+fn take_events_ring(bpf: &mut Ebpf) -> io::Result<RingBuf<MapData>> {
+    for name in ["events", "EVENTS"] {
+        if let Some(map) = bpf.take_map(name) {
+            return RingBuf::try_from(map).map_err(|err| {
+                io::Error::other(format!("failed to open ring buffer {name}: {err}"))
+            });
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "events ring buffer not found",
+    ))
+}
+
+fn start_agent(ring: RingBuf<MapData>, events_path: PathBuf) -> io::Result<AgentHandle> {
+    let cfg = AgentConfig::default();
+    let (shutdown, signal) = Shutdown::new(Duration::from_millis(100));
+    let thread = thread::Builder::new()
+        .name("qqrm-agent-lite".into())
+        .spawn(move || qqrm_agent_lite::run_with_shutdown(ring, &events_path, cfg, signal))
+        .map_err(|err| io::Error::other(format!("failed to spawn agent thread: {err}")))?;
+    Ok(AgentHandle {
+        shutdown,
+        thread: Some(thread),
+    })
+}
+
+fn join_cgroup_fd(fd: RawFd) -> io::Result<()> {
+    let data = b"0\n";
+    let offset = unsafe { libc::lseek(fd, 0, libc::SEEK_SET) };
+    if offset < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let written = unsafe { libc::write(fd, data.as_ptr() as *const _, data.len()) };
+    if written < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn events_path() -> PathBuf {
+    if let Some(path) = env::var_os("QQRM_WARDEN_EVENTS_PATH") {
+        PathBuf::from(path)
+    } else {
+        PathBuf::from("warden-events.jsonl")
+    }
+}
+
+fn fake_cgroup_dir() -> PathBuf {
+    if let Some(path) = env::var_os("QQRM_WARDEN_FAKE_CGROUP_DIR") {
+        PathBuf::from(path)
+    } else {
+        let root = env::var_os("QQRM_WARDEN_FAKE_CGROUP_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(env::temp_dir);
+        root.join(format!(
+            "fake-cargo-warden-{}-{}",
+            process::id(),
+            unique_suffix()
+        ))
+    }
+}
+
+fn program_not_found(name: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("missing BPF program {name}"),
+    )
+}
+
+fn unique_suffix() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros())
+        .unwrap_or(0)
+}

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,0 +1,32 @@
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let events_path = dir.path().join("warden-events.jsonl");
+    let cgroup_path = dir.path().join("fake-cgroup");
+
+    let mut cmd = Command::cargo_bin("cargo-warden")?;
+    cmd.arg("run")
+        .arg("--")
+        .arg("true")
+        .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
+        .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path);
+    cmd.assert().success();
+
+    let contents = fs::read_to_string(&events_path)?;
+    assert!(
+        contents.lines().any(|line| line.contains("\"fake\":true")),
+        "expected fake event in {}: {contents}",
+        events_path.display()
+    );
+    assert!(
+        !cgroup_path.exists(),
+        "expected fake cgroup removal: {}",
+        cgroup_path.display()
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a sandbox abstraction that loads the qqrm-bpf-core object, prepares a cgroup, runs the agent, and tears everything down
- switch the build and run subcommands to execute commands inside the sandbox helper
- extend the agent-lite crate with shutdown handling and add an integration test that exercises the fake sandbox path

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test *(fails: missing libseccomp system library in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb764e70a4833296f839bdbf3bb400