### PR TITLE
feat(cli): initialize policy with schema-compliant template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,7 +1061,9 @@ dependencies = [
  "qqrm-policy-core",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,8 +16,10 @@ libc = "0.2"
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 [dev-dependencies]
+serial_test = "3"
 tempfile = "3"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- update `handle_init_with` to emit a minimal policy matching the documented schema
- refresh CLI init tests to cover the new format and to parse the generated policy via `Policy::from_toml_str`
- add directory guards and serial test annotations so init/report tests do not interfere with each other

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68cb7f2236a88332887d30ec77c90e64