### PR TITLE
Add filesystem rule maps and permission checks

### DIFF
--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -11,6 +11,8 @@ pub const EXEC_ALLOWLIST_CAPACITY: u32 = 64;
 pub const NET_RULES_CAPACITY: u32 = 256;
 /// Maximum number of parent relationships supported by the eBPF map.
 pub const NET_PARENTS_CAPACITY: u32 = 256;
+/// Maximum number of filesystem rules supported by the eBPF map.
+pub const FS_RULES_CAPACITY: u32 = 256;
 /// Size of the event ring buffer in bytes.
 pub const EVENT_RINGBUF_CAPACITY_BYTES: u32 = 4096;
 /// Number of slots tracked for emitted event counters.


### PR DESCRIPTION
## Summary
- add FS_RULES map definitions with host-mode backing storage and expose their lengths
- implement filesystem path matching helpers with unit inheritance and permission bit handling
- update file_open/file_permission/inode_unlink to read user paths, consult filesystem rules, and extend host-mode tests

## Testing
- cargo fmt
- cargo test -p qqrm-bpf-core
- cargo clippy -p qqrm-bpf-core --tests
- cargo check --tests --benches *(fails: crates/cli/src/main.rs still targets the previous policy_core API)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd69b565083328dc4c712c1905b62