### PR TITLE
Add tests covering filesystem rule prefixes

### DIFF
--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -992,6 +992,38 @@ mod tests {
     }
 
     #[test]
+    fn file_permission_allows_prefix_rule() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
+        reset_fs_state();
+        let rule_path = "/workspace/data";
+        set_fs_rules(&[fs_rule_entry(0, rule_path, FS_READ | FS_WRITE)]);
+        let file_path = c_string("/workspace/data/subdir/file.txt");
+        let mut file = TestFile {
+            path: file_path.as_ptr(),
+            mode: FMODE_READ,
+        };
+        let file_ptr = (&mut file) as *mut _ as *mut c_void;
+        assert_eq!(file_permission(file_ptr, MAY_READ), 0);
+    }
+
+    #[test]
+    fn file_permission_denies_mismatched_prefix() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
+        reset_fs_state();
+        let rule_path = "/workspace/data";
+        set_fs_rules(&[fs_rule_entry(0, rule_path, FS_READ | FS_WRITE)]);
+        let file_path = c_string("/workspace/database");
+        let mut file = TestFile {
+            path: file_path.as_ptr(),
+            mode: FMODE_READ,
+        };
+        let file_ptr = (&mut file) as *mut _ as *mut c_void;
+        assert_ne!(file_permission(file_ptr, MAY_READ), 0);
+    }
+
+    #[test]
     fn inode_unlink_requires_write_permission() {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();


### PR DESCRIPTION
## Summary
- add unit tests verifying filesystem permission rules allow nested paths
- add regression coverage ensuring mismatched prefixes are denied

## Testing
- 
-  *(fails: cli crate still references legacy policy_core fields)*
- 
- 
- 
running 9 tests
test tests::connect4_respects_rules ... ok
test tests::connect6_respects_rules ... ok
test tests::file_open_denies_without_rule ... ok
test tests::file_open_emits_event ... ok
test tests::file_permission_allows_prefix_rule ... ok
test tests::file_permission_denies_mismatched_prefix ... ok
test tests::file_permission_respects_access_bits ... ok
test tests::file_rules_inherit_across_units ... ok
test tests::inode_unlink_requires_write_permission ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- cargo-machete didn't find any unused dependencies in this directory. Good job!
