### PR TITLE
Handle filesystem denial events across agent and CLI

### DIFF
--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -5,6 +5,9 @@ pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
 pub const FS_WRITE: u8 = 2;
 
+/// Action code emitted when filesystem access is denied.
+pub const ACTION_FS_DENIED: u8 = 5;
+
 /// Maximum number of exec allowlist entries supported by the eBPF map.
 pub const EXEC_ALLOWLIST_CAPACITY: u32 = 64;
 /// Maximum number of network rules supported by the eBPF map.

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -344,7 +344,7 @@ struct RawEnvAllow {
     read: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PolicyOverride {
     raw: RawPolicyOverride,
 }
@@ -352,14 +352,6 @@ pub struct PolicyOverride {
 impl PolicyOverride {
     fn raw(&self) -> &RawPolicyOverride {
         &self.raw
-    }
-}
-
-impl Default for PolicyOverride {
-    fn default() -> Self {
-        Self {
-            raw: RawPolicyOverride::default(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a shared `ACTION_FS_DENIED` code and ensure the filesystem LSM hooks always emit paths with the denial verdict
- expose filesystem denials through the agent diagnostics and CLI event handling while deduplicating policy rules with the flattened schema
- derive defaults for `PolicyOverride` to satisfy the updated policy API

## Testing
- `apt-get update`
- `apt-get install -y libseccomp-dev`
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68cbe9dae58c83328be2f261306ad621