### PR TITLE
Document filesystem denial event code in ABI guide

### DIFF
--- a/EVENT_LOG_ABI.md
+++ b/EVENT_LOG_ABI.md
@@ -8,7 +8,7 @@ The eBPF layer emits `Event` records via a ring buffer. This ABI defines the lay
 pub struct Event {
     pub pid: u32,
     pub unit: u8,        // 0 Other, 1 BuildRs, 2 ProcMacro, 3 Rustc, 4 Linker
-    pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
+    pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect, 5 FsDenied
     pub verdict: u8,     // 0 Allowed, 1 Denied
     pub reserved: u8,    // padding for alignment, reserved for future use
     pub container_id: u64,
@@ -20,6 +20,12 @@ pub struct Event {
 - **pid** – process identifier.
 - **unit** – workload category generating the event.
 - **action** – operation being audited.
+  - `0`: Filesystem open attempt.
+  - `1`: Filesystem rename attempt.
+  - `2`: Filesystem unlink attempt.
+  - `3`: Execution request.
+  - `4`: Network connection attempt.
+  - `5`: Filesystem access denied by policy. The associated path is stored in `path_or_addr`.
 - **path_or_addr** – associated filesystem path or network address.
 - **verdict** – allow (`0`) or deny (`1`).
 - **container_id** – identifier of the container or sandbox.

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -5,6 +5,9 @@ pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
 pub const FS_WRITE: u8 = 2;
 
+/// Action code emitted when filesystem access is denied.
+pub const ACTION_FS_DENIED: u8 = 5;
+
 /// Maximum number of exec allowlist entries supported by the eBPF map.
 pub const EXEC_ALLOWLIST_CAPACITY: u32 = 64;
 /// Maximum number of network rules supported by the eBPF map.

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -344,7 +344,7 @@ struct RawEnvAllow {
     read: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PolicyOverride {
     raw: RawPolicyOverride,
 }
@@ -352,14 +352,6 @@ pub struct PolicyOverride {
 impl PolicyOverride {
     fn raw(&self) -> &RawPolicyOverride {
         &self.raw
-    }
-}
-
-impl Default for PolicyOverride {
-    fn default() -> Self {
-        Self {
-            raw: RawPolicyOverride::default(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- document the ACTION_FS_DENIED constant alongside the other event action codes
- describe the meaning of each action value in the ABI reference, noting that filesystem denials carry the offending path

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete