### PR TITLE
Record fake sandbox layouts

### DIFF
--- a/crates/cli/src/sandbox.rs
+++ b/crates/cli/src/sandbox.rs
@@ -8,11 +8,13 @@ use aya::{Btf, Ebpf, EbpfLoader, Pod};
 use bpf_api::{ExecAllowEntry, FsRuleEntry, NetParentEntry, NetRuleEntry};
 use qqrm_agent_lite::{self, Config as AgentConfig, Shutdown, ShutdownHandle};
 use qqrm_policy_compiler::MapsLayout;
+use serde::Serialize;
 use std::cell::UnsafeCell;
 use std::convert::TryFrom;
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
+use std::net::{Ipv4Addr, Ipv6Addr};
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -419,6 +421,7 @@ impl Drop for Cgroup {
 struct FakeSandbox {
     cgroup_dir: PathBuf,
     agent: Option<FakeAgent>,
+    layout_recorder: Option<LayoutRecorder>,
 }
 
 impl FakeSandbox {
@@ -433,13 +436,18 @@ impl FakeSandbox {
         }
         fs::create_dir_all(&cgroup_dir)?;
         let agent = FakeAgent::spawn(events)?;
+        let layout_recorder = LayoutRecorder::from_env()?;
         Ok(Self {
             cgroup_dir,
             agent: Some(agent),
+            layout_recorder,
         })
     }
 
-    fn run(&mut self, mut command: Command, _layout: &MapsLayout) -> io::Result<ExitStatus> {
+    fn run(&mut self, mut command: Command, layout: &MapsLayout) -> io::Result<ExitStatus> {
+        if let Some(recorder) = &mut self.layout_recorder {
+            recorder.record(layout)?;
+        }
         command.status()
     }
 
@@ -451,6 +459,129 @@ impl FakeSandbox {
             fs::remove_dir_all(&self.cgroup_dir)?;
         }
         Ok(())
+    }
+}
+
+struct LayoutRecorder {
+    file: File,
+}
+
+impl LayoutRecorder {
+    fn from_env() -> io::Result<Option<Self>> {
+        match env::var_os("QQRM_WARDEN_FAKE_LAYOUT_PATH") {
+            Some(path) => {
+                let path = PathBuf::from(path);
+                if let Some(parent) = path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let file = OpenOptions::new().create(true).append(true).open(&path)?;
+                Ok(Some(Self { file }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn record(&mut self, layout: &MapsLayout) -> io::Result<()> {
+        let snapshot = LayoutSnapshot::from(layout);
+        serde_json::to_writer(&mut self.file, &snapshot).map_err(io::Error::other)?;
+        self.file.write_all(b"\n")?;
+        self.file.flush()
+    }
+}
+
+#[derive(Serialize)]
+struct LayoutSnapshot {
+    exec_allowlist: Vec<String>,
+    net_rules: Vec<LayoutNetRule>,
+    net_parents: Vec<LayoutNetParent>,
+    fs_rules: Vec<LayoutFsRule>,
+}
+
+impl From<&MapsLayout> for LayoutSnapshot {
+    fn from(layout: &MapsLayout) -> Self {
+        Self {
+            exec_allowlist: layout
+                .exec_allowlist
+                .iter()
+                .map(|entry| decode_path(&entry.path))
+                .collect(),
+            net_rules: layout.net_rules.iter().map(LayoutNetRule::from).collect(),
+            net_parents: layout
+                .net_parents
+                .iter()
+                .map(LayoutNetParent::from)
+                .collect(),
+            fs_rules: layout.fs_rules.iter().map(LayoutFsRule::from).collect(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LayoutNetRule {
+    unit: u32,
+    addr: String,
+    protocol: u8,
+    prefix_len: u8,
+    port: u16,
+}
+
+impl From<&NetRuleEntry> for LayoutNetRule {
+    fn from(entry: &NetRuleEntry) -> Self {
+        Self {
+            unit: entry.unit,
+            addr: format_addr(&entry.rule.addr, entry.rule.prefix_len),
+            protocol: entry.rule.protocol,
+            prefix_len: entry.rule.prefix_len,
+            port: entry.rule.port,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LayoutNetParent {
+    child: u32,
+    parent: u32,
+}
+
+impl From<&NetParentEntry> for LayoutNetParent {
+    fn from(entry: &NetParentEntry) -> Self {
+        Self {
+            child: entry.child,
+            parent: entry.parent,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LayoutFsRule {
+    unit: u32,
+    access: u8,
+    path: String,
+}
+
+impl From<&FsRuleEntry> for LayoutFsRule {
+    fn from(entry: &FsRuleEntry) -> Self {
+        Self {
+            unit: entry.unit,
+            access: entry.rule.access,
+            path: decode_path(&entry.rule.path),
+        }
+    }
+}
+
+fn decode_path(bytes: &[u8; 256]) -> String {
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
+    String::from_utf8_lossy(&bytes[..end]).into_owned()
+}
+
+fn format_addr(bytes: &[u8; 16], prefix_len: u8) -> String {
+    if prefix_len <= 32 && bytes[4..].iter().all(|&b| b == 0) {
+        let ipv4 = Ipv4Addr::new(bytes[0], bytes[1], bytes[2], bytes[3]);
+        ipv4.to_string()
+    } else {
+        let mut addr = [0u8; 16];
+        addr.copy_from_slice(bytes);
+        Ipv6Addr::from(addr).to_string()
     }
 }
 

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,21 +1,105 @@
 use assert_cmd::Command;
+use serde::Deserialize;
 use std::fs;
 use tempfile::tempdir;
 
+#[derive(Debug, Deserialize)]
+struct LayoutSnapshot {
+    exec_allowlist: Vec<String>,
+    net_rules: Vec<LayoutNetRule>,
+    fs_rules: Vec<LayoutFsRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayoutNetRule {
+    addr: String,
+    protocol: u8,
+    port: u16,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayoutFsRule {
+    access: u8,
+    path: String,
+}
+
 #[test]
-fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
+fn run_fake_sandbox_records_layout() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempdir()?;
+    let layout_path = dir.path().join("fake-layouts.jsonl");
     let events_path = dir.path().join("warden-events.jsonl");
     let cgroup_path = dir.path().join("fake-cgroup");
+    let policy_path = dir.path().join("policy.toml");
+
+    fs::write(
+        &policy_path,
+        r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "deny"
+exec.default = "allowlist"
+
+[allow.net]
+hosts = ["127.0.0.1:8080"]
+
+[allow.fs]
+write_extra = ["/tmp/logs"]
+read_extra = ["/etc/resolv.conf"]
+"#,
+    )?;
 
     let mut cmd = Command::cargo_bin("cargo-warden")?;
-    cmd.arg("run")
+    cmd.arg("--allow")
+        .arg("/bin/echo")
+        .arg("--policy")
+        .arg(&policy_path)
+        .arg("run")
         .arg("--")
         .arg("true")
+        .current_dir(dir.path())
         .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
         .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
-        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path);
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path);
     cmd.assert().success();
+
+    let layout_log = fs::read_to_string(&layout_path)?;
+    let snapshot_line = layout_log
+        .lines()
+        .last()
+        .ok_or_else(|| format!("missing layout snapshot in {}", layout_path.display()))?;
+    let snapshot: LayoutSnapshot = serde_json::from_str(snapshot_line)?;
+
+    assert!(
+        snapshot
+            .exec_allowlist
+            .iter()
+            .any(|path| path == "/bin/echo"),
+        "expected exec allowlist entry for /bin/echo: {:?}",
+        snapshot.exec_allowlist
+    );
+    assert!(
+        snapshot
+            .net_rules
+            .iter()
+            .any(|rule| rule.addr == "127.0.0.1" && rule.port == 8080 && rule.protocol == 6),
+        "expected net rule for 127.0.0.1:8080, found {:?}",
+        snapshot.net_rules
+    );
+    assert!(
+        snapshot.fs_rules.iter().any(|rule| rule.path == "/tmp/logs"
+            && rule.access == (bpf_api::FS_READ | bpf_api::FS_WRITE)),
+        "expected fs write rule for /tmp/logs, found {:?}",
+        snapshot.fs_rules
+    );
+    assert!(
+        snapshot
+            .fs_rules
+            .iter()
+            .any(|rule| rule.path == "/etc/resolv.conf" && rule.access == bpf_api::FS_READ),
+        "expected fs read rule for /etc/resolv.conf, found {:?}",
+        snapshot.fs_rules
+    );
 
     let contents = fs::read_to_string(&events_path)?;
     assert!(
@@ -28,5 +112,6 @@ fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
         "expected fake cgroup removal: {}",
         cgroup_path.display()
     );
+    dir.close()?;
     Ok(())
 }

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -344,7 +344,7 @@ struct RawEnvAllow {
     read: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PolicyOverride {
     raw: RawPolicyOverride,
 }
@@ -352,14 +352,6 @@ pub struct PolicyOverride {
 impl PolicyOverride {
     fn raw(&self) -> &RawPolicyOverride {
         &self.raw
-    }
-}
-
-impl Default for PolicyOverride {
-    fn default() -> Self {
-        Self {
-            raw: RawPolicyOverride::default(),
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- record fake sandbox map layouts to JSONL output for integration tests
- align CLI policy merging and deduplication with the permission-based representation
- extend the fake sandbox integration test to validate exec/net/fs rules and isolate temp artifacts

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
