### PR TITLE
Record fake sandbox layout

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-qqrm-agent-lite = { path = "../agent-lite" }
+qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,21 +1,118 @@
 use assert_cmd::Command;
+use serde::Deserialize;
 use std::fs;
 use tempfile::tempdir;
 
+#[derive(Debug, Deserialize)]
+struct LayoutSnapshot {
+    exec_allowlist: Vec<String>,
+    net_rules: Vec<LayoutNetRule>,
+    net_parents: Vec<LayoutNetParent>,
+    fs_rules: Vec<LayoutFsRule>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayoutNetRule {
+    addr: String,
+    protocol: u8,
+    port: u16,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct LayoutNetParent {
+    child: u32,
+    parent: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct LayoutFsRule {
+    access: u8,
+    path: String,
+}
+
 #[test]
-fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
+fn run_fake_sandbox_records_layout() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempdir()?;
+    let layout_path = dir.path().join("fake-layouts.jsonl");
     let events_path = dir.path().join("warden-events.jsonl");
     let cgroup_path = dir.path().join("fake-cgroup");
+    let policy_path = dir.path().join("policy.toml");
+
+    fs::write(
+        &policy_path,
+        r#"
+mode = "enforce"
+fs.default = "strict"
+net.default = "deny"
+exec.default = "allowlist"
+
+[allow.net]
+hosts = ["127.0.0.1:8080"]
+
+[allow.fs]
+write_extra = ["/tmp/logs"]
+read_extra = ["/etc/resolv.conf"]
+"#,
+    )?;
 
     let mut cmd = Command::cargo_bin("cargo-warden")?;
-    cmd.arg("run")
+    cmd.arg("--allow")
+        .arg("/bin/echo")
+        .arg("--policy")
+        .arg(&policy_path)
+        .arg("run")
         .arg("--")
         .arg("true")
+        .current_dir(dir.path())
         .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
         .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
-        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path);
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path);
     cmd.assert().success();
+
+    let layout_log = fs::read_to_string(&layout_path)?;
+    let snapshot_line = layout_log
+        .lines()
+        .last()
+        .ok_or_else(|| format!("missing layout snapshot in {}", layout_path.display()))?;
+    let snapshot: LayoutSnapshot = serde_json::from_str(snapshot_line)?;
+
+    assert!(
+        snapshot
+            .exec_allowlist
+            .iter()
+            .any(|path| path == "/bin/echo"),
+        "expected exec allowlist entry for /bin/echo: {:?}",
+        snapshot.exec_allowlist
+    );
+    assert!(
+        snapshot
+            .net_rules
+            .iter()
+            .any(|rule| rule.addr == "127.0.0.1" && rule.port == 8080 && rule.protocol == 6),
+        "expected net rule for 127.0.0.1:8080, found {:?}",
+        snapshot.net_rules
+    );
+    assert!(
+        snapshot.fs_rules.iter().any(|rule| rule.path == "/tmp/logs"
+            && rule.access == (bpf_api::FS_READ | bpf_api::FS_WRITE)),
+        "expected fs write rule for /tmp/logs, found {:?}",
+        snapshot.fs_rules
+    );
+    assert!(
+        snapshot
+            .fs_rules
+            .iter()
+            .any(|rule| rule.path == "/etc/resolv.conf" && rule.access == bpf_api::FS_READ),
+        "expected fs read rule for /etc/resolv.conf, found {:?}",
+        snapshot.fs_rules
+    );
+    assert!(
+        snapshot.net_parents.is_empty(),
+        "expected no net parent entries, found {:?}",
+        snapshot.net_parents
+    );
 
     let contents = fs::read_to_string(&events_path)?;
     assert!(
@@ -28,5 +125,6 @@ fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
         "expected fake cgroup removal: {}",
         cgroup_path.display()
     );
+    dir.close()?;
     Ok(())
 }

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -344,7 +344,7 @@ struct RawEnvAllow {
     read: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PolicyOverride {
     raw: RawPolicyOverride,
 }
@@ -352,14 +352,6 @@ pub struct PolicyOverride {
 impl PolicyOverride {
     fn raw(&self) -> &RawPolicyOverride {
         &self.raw
-    }
-}
-
-impl Default for PolicyOverride {
-    fn default() -> Self {
-        Self {
-            raw: RawPolicyOverride::default(),
-        }
     }
 }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-bpf-core = { package = "qqrm-bpf-core", path = "../crates/bpf-core", features = ["fuzzing"] }
+bpf-core = { package = "qqrm-bpf-core", version = "0.1.0", path = "../crates/bpf-core", features = ["fuzzing"] }
 
 [[bin]]
 name = "net"


### PR DESCRIPTION
## Summary
- log fake sandbox map layouts to a JSONL file when QQRM_WARDEN_FAKE_LAYOUT_PATH is set.
- ensure the fake sandbox recorder retains a single implementation that writes exec/net/fs data with decoded addresses.
- expand the integration test to assert exec/net/fs entries, absence of net parents, and clean isolation.

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cbec5a1b04833293d214b948ab8bf6