### PR TITLE
Resolve CLI policy merge conflicts

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-qqrm-agent-lite = { path = "../agent-lite" }
+qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -227,8 +227,9 @@ fn parse_policy_from_str(path: &Path, text: &str) -> io::Result<Policy> {
 }
 
 fn merge_policy(base: &mut Policy, extra: Policy) {
-    base.mode = extra.mode;
-    base.rules.extend(extra.rules);
+    let Policy { mode, mut rules } = extra;
+    base.mode = mode;
+    base.rules.append(&mut rules);
 }
 
 fn dedup_policy_lists(policy: &mut Policy) {
@@ -243,6 +244,8 @@ fn dedup_policy_lists(policy: &mut Policy) {
     let mut seen_syscall: HashSet<&String> = HashSet::new();
     let mut seen_env: HashSet<&String> = HashSet::new();
 
+    // Walk from the end so the last override of each rule type wins while we keep
+    // the rules in their original order.
     for (index, perm) in policy.rules.iter().enumerate().rev() {
         let should_keep = match perm {
             Exec(path) => seen_exec.insert(path),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-bpf-core = { package = "qqrm-bpf-core", path = "../crates/bpf-core", features = ["fuzzing"] }
+bpf-core = { package = "qqrm-bpf-core", version = "0.1.0", path = "../crates/bpf-core", features = ["fuzzing"] }
 
 [[bin]]
 name = "net"


### PR DESCRIPTION
## Summary
- append merged policy permissions without reallocations so CLI overrides stay intact `F:crates/cli/src/main.rs#L229-L248`
- document why dedup walks from the tail so the latest rule override wins without reordering `F:crates/cli/src/main.rs#L247-L253`
- declare versions for local CLI and fuzz dependencies to satisfy path-version checks `F:crates/cli/Cargo.toml#L18-L24` `F:fuzz/Cargo.toml#L10-L13`

## Avatar
- Senior Rust Developer — chosen to reconcile Rust CLI policy merging with upstream changes.

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- cargo check -p qqrm-cargo-warden
- ./scripts/check_path_versions.sh
