### PR TITLE
Record fake sandbox layout snapshots

### DIFF
--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,21 +1,134 @@
 use assert_cmd::Command;
+use serde::Deserialize;
 use std::fs;
 use tempfile::tempdir;
 
+#[derive(Debug, Deserialize)]
+struct LayoutSnapshot {
+    exec: Vec<String>,
+    net: Vec<NetRuleSnapshot>,
+    net_parents: Vec<NetParentSnapshot>,
+    fs: Vec<FsRuleSnapshot>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct NetRuleSnapshot {
+    unit: u32,
+    protocol: u8,
+    prefix_len: u8,
+    port: u16,
+    addr: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct NetParentSnapshot {
+    child: u32,
+    parent: u32,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct FsRuleSnapshot {
+    unit: u32,
+    path: String,
+    read: bool,
+    write: bool,
+}
+
 #[test]
-fn run_fake_sandbox_records_events() -> Result<(), Box<dyn std::error::Error>> {
+fn run_fake_sandbox_records_layout() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempdir()?;
     let events_path = dir.path().join("warden-events.jsonl");
+    let layout_path = dir.path().join("fake-layout.jsonl");
     let cgroup_path = dir.path().join("fake-cgroup");
+    let policy_path = dir.path().join("policy.toml");
+
+    fs::write(
+        &policy_path,
+        r#"
+mode = "enforce"
+
+[fs]
+default = "strict"
+
+[net]
+default = "deny"
+
+[exec]
+default = "allowlist"
+
+[allow.net]
+hosts = ["127.0.0.1:8080"]
+
+[allow.fs]
+write_extra = ["/tmp/logs"]
+read_extra = ["/etc/ssl/certs"]
+"#,
+    )?;
 
     let mut cmd = Command::cargo_bin("cargo-warden")?;
     cmd.arg("run")
+        .arg("--allow")
+        .arg("/bin/echo")
+        .arg("--policy")
+        .arg(&policy_path)
         .arg("--")
         .arg("true")
+        .current_dir(dir.path())
         .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
         .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
-        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path);
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path);
     cmd.assert().success();
+
+    let layout_contents = fs::read_to_string(&layout_path)?;
+    let snapshots: Vec<LayoutSnapshot> = layout_contents
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<_, _>>()?;
+    assert!(
+        !snapshots.is_empty(),
+        "expected at least one layout snapshot in {}",
+        layout_path.display()
+    );
+    let snapshot = snapshots.last().unwrap();
+
+    assert!(
+        snapshot.exec.iter().any(|path| path == "/bin/echo"),
+        "expected exec allowlist entry for /bin/echo: {:?}",
+        snapshot.exec
+    );
+    assert!(
+        snapshot
+            .net
+            .iter()
+            .any(|rule| rule.addr == "127.0.0.1" && rule.port == 8080),
+        "expected net rule for 127.0.0.1:8080: {:?}",
+        snapshot.net
+    );
+    assert!(
+        snapshot.net_parents.is_empty(),
+        "expected no net parents: {:?}",
+        snapshot.net_parents
+    );
+    assert!(
+        snapshot
+            .fs
+            .iter()
+            .any(|rule| rule.path == "/tmp/logs" && rule.write),
+        "expected write rule for /tmp/logs: {:?}",
+        snapshot.fs
+    );
+    assert!(
+        snapshot
+            .fs
+            .iter()
+            .any(|rule| rule.path == "/etc/ssl/certs" && rule.read && !rule.write),
+        "expected read-only rule for /etc/ssl/certs: {:?}",
+        snapshot.fs
+    );
 
     let contents = fs::read_to_string(&events_path)?;
     assert!(


### PR DESCRIPTION
## Summary
- Record each fake sandbox maps layout snapshot to a JSONL log when QQRM_WARDEN_FAKE_LAYOUT_PATH is configured, decoding exec, net, and fs entries for inspection. F:crates/cli/src/sandbox.rs#L421-L597
- Extend the fake sandbox integration test to run in a temp directory, feed allow/policy inputs, and assert the recorded exec/net/fs entries while keeping cleanup assertions. F:crates/cli/tests/sandbox.rs#L6-L145
- Avatar: Senior Rust Developer — chosen to refactor sandbox plumbing and author comprehensive Rust tests.

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
