### PR TITLE
Add mode override to CLI and GitHub Action

### DIFF
--- a/.github/workflows/Warden CI.yml
+++ b/.github/workflows/Warden CI.yml
@@ -9,3 +9,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./warden-ci
+        with:
+          mode: observe

--- a/warden-ci/README.md
+++ b/warden-ci/README.md
@@ -7,6 +7,7 @@ Runs `cargo-warden` in CI, generates a SARIF report and uploads it for pull requ
 | Name | Description | Default |
 | ---- | ----------- | ------- |
 | `command` | Cargo command to run under `cargo-warden`. | `build` |
+| `mode` | Sandbox mode to run (`observe` or `enforce`). | `enforce` |
 
 ## Usage
 
@@ -24,6 +25,7 @@ jobs:
       - uses: owner/warden-ci@v1
         with:
           command: build
+          mode: observe
 ```
 
 ## PR Annotations

--- a/warden-ci/action.yml
+++ b/warden-ci/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Cargo command to run under cargo-warden'
     required: false
     default: 'build'
+  mode:
+    description: 'Sandbox mode to use (observe or enforce)'
+    required: false
+    default: 'enforce'
 runs:
   using: 'composite'
   steps:
@@ -19,9 +23,29 @@ runs:
     - name: Install cargo-warden
       shell: bash
       run: cargo install --path crates/cli
-    - name: Enforce ${{ inputs.command }}
+    - name: Run cargo warden ${{ inputs.command }}
       shell: bash
-      run: cargo warden ${{ inputs.command }} || true
+      run: |
+        set -euo pipefail
+        MODE="${{ inputs.mode }}"
+        case "$MODE" in
+          observe|enforce) ;;
+          *)
+            echo "Invalid mode: $MODE" >&2
+            exit 1
+            ;;
+        esac
+        set +e
+        cargo warden --mode "$MODE" ${{ inputs.command }}
+        status=$?
+        set -e
+        if [[ $status -ne 0 ]]; then
+          if [[ "$MODE" == "enforce" ]]; then
+            echo "::warning::cargo warden reported violations in enforce mode (exit $status)" >&2
+          else
+            exit $status
+          fi
+        fi
     - name: Generate SARIF report
       shell: bash
       run: cargo warden report --output warden.sarif


### PR DESCRIPTION
## Summary
* Add a `--mode` override to the CLI so CI can flip between enforce and observe policies without editing repository configuration. F:crates/cli/src/main.rs#L15-L237
* Extend the CLI test suite to cover the new flag parsing and mode override semantics. F:crates/cli/src/main.rs#L530-L890
* Allow the composite GitHub Action (and its workflow example) to accept a mode input, validate it, and default the workflow to observe mode. F:warden-ci/action.yml#L3-L49 F:warden-ci/README.md#L7-L28 F:.github/workflows/Warden CI.yml#L1-L13

## Testing
* `cargo fmt --all`
* `cargo check --tests --benches`
* `cargo clippy --all-targets --all-features -- -D warnings`
* `cargo test`
* `cargo machete`
* `actionlint`

### Avatar
* Working as the DevOps Engineer avatar because this change tunes our GitHub Actions integration.


------
https://chatgpt.com/codex/tasks/task_e_68cc0a88a67483329d7992c7f2a61e1a