### PR TITLE
Add implicit Cargo filesystem allowances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1219,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "aya",
+ "cargo_metadata",
  "clap",
  "libc",
  "libseccomp",
@@ -1424,19 +1457,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ libseccomp = "0.3"
 bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
+cargo_metadata = "0.18"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,13 @@
+use bpf_api::{FS_READ, FS_WRITE, FsRule, FsRuleEntry};
+use cargo_metadata::MetadataCommand;
 use clap::{Parser, Subcommand};
 use policy_core::{ExecDefault, FsDefault, Mode, NetDefault, Permission, Policy};
 use qqrm_policy_compiler::{self, MapsLayout};
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, exit};
 
 mod sandbox;
@@ -194,12 +196,162 @@ fn setup_isolation(allow: &[String], policy_paths: &[String]) -> io::Result<Isol
         eprintln!("warning: {warn}");
     }
 
-    let layout = qqrm_policy_compiler::compile(&policy)
+    let mut layout = qqrm_policy_compiler::compile(&policy)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    merge_implicit_fs_rules(&mut layout)?;
 
     Ok(IsolationConfig {
         syscall_deny: policy.syscall_deny().cloned().collect(),
         maps_layout: layout,
+    })
+}
+
+struct CargoPaths {
+    workspace: Option<PathBuf>,
+    target: Option<PathBuf>,
+    out_dir: Option<PathBuf>,
+}
+
+fn merge_implicit_fs_rules(layout: &mut MapsLayout) -> io::Result<()> {
+    let mut combined: BTreeMap<(u32, PathBuf), u8> = BTreeMap::new();
+    for entry in layout.fs_rules.drain(..) {
+        let path = decode_fs_rule_path(&entry)?;
+        let key = (entry.unit, path);
+        combined
+            .entry(key)
+            .and_modify(|access| *access |= entry.rule.access)
+            .or_insert(entry.rule.access);
+    }
+
+    let mut units: BTreeSet<u32> = combined.keys().map(|(unit, _)| *unit).collect();
+    if units.is_empty() {
+        units.insert(0);
+    }
+    let units: Vec<u32> = units.into_iter().collect();
+
+    let paths = discover_cargo_paths()?;
+    let mut add_path = |path: &Path, access: u8| {
+        let normalized = path.to_path_buf();
+        for unit in &units {
+            let key = (*unit, normalized.clone());
+            combined
+                .entry(key)
+                .and_modify(|existing| *existing |= access)
+                .or_insert(access);
+        }
+    };
+
+    if let Some(workspace) = paths.workspace.as_deref() {
+        add_path(workspace, FS_READ);
+    }
+    if let Some(target) = paths.target.as_deref() {
+        add_path(target, FS_READ | FS_WRITE);
+    }
+    if let Some(out_dir) = paths.out_dir.as_deref() {
+        add_path(out_dir, FS_READ | FS_WRITE);
+    }
+
+    layout.fs_rules = combined
+        .into_iter()
+        .map(|((unit, path), access)| fs_rule_entry_from_path(&path, access, unit))
+        .collect::<io::Result<Vec<_>>>()?;
+
+    Ok(())
+}
+
+fn discover_cargo_paths() -> io::Result<CargoPaths> {
+    let workspace_env = std::env::var_os("CARGO_WORKSPACE_DIR").map(PathBuf::from);
+    let manifest_env = std::env::var_os("CARGO_MANIFEST_DIR").map(PathBuf::from);
+    let target_env = std::env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
+    let out_dir_env = std::env::var_os("OUT_DIR").map(PathBuf::from);
+
+    let metadata_dir_hint = workspace_env.as_deref().or(manifest_env.as_deref());
+    let need_metadata = workspace_env.is_none() || target_env.is_none();
+    let metadata = if need_metadata {
+        Some(load_metadata(metadata_dir_hint)?)
+    } else {
+        None
+    };
+
+    let workspace = if let Some(path) = workspace_env {
+        Some(ensure_absolute(path)?)
+    } else if let Some(meta) = metadata.as_ref() {
+        Some(ensure_absolute(
+            meta.workspace_root.clone().into_std_path_buf(),
+        )?)
+    } else {
+        None
+    };
+
+    let target = if let Some(path) = target_env {
+        Some(ensure_absolute(path)?)
+    } else if let Some(meta) = metadata.as_ref() {
+        Some(ensure_absolute(
+            meta.target_directory.clone().into_std_path_buf(),
+        )?)
+    } else {
+        None
+    };
+
+    let out_dir = if let Some(path) = out_dir_env {
+        Some(ensure_absolute(path)?)
+    } else {
+        None
+    };
+
+    Ok(CargoPaths {
+        workspace,
+        target,
+        out_dir,
+    })
+}
+
+fn load_metadata(dir: Option<&Path>) -> io::Result<cargo_metadata::Metadata> {
+    let mut command = MetadataCommand::new();
+    command.no_deps();
+    if let Some(dir) = dir {
+        command.current_dir(dir);
+    }
+    command.exec().map_err(io::Error::other)
+}
+
+fn ensure_absolute(path: PathBuf) -> io::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path)
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+fn decode_fs_rule_path(entry: &FsRuleEntry) -> io::Result<PathBuf> {
+    let len = entry
+        .rule
+        .path
+        .iter()
+        .position(|&byte| byte == 0)
+        .unwrap_or(entry.rule.path.len());
+    let path_slice = &entry.rule.path[..len];
+    let path = std::str::from_utf8(path_slice)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    Ok(PathBuf::from(path))
+}
+
+fn fs_rule_entry_from_path(path: &Path, access: u8, unit: u32) -> io::Result<FsRuleEntry> {
+    let path_str = path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("filesystem path '{path:?}' contains invalid UTF-8"),
+        )
+    })?;
+    let encoded = qqrm_policy_compiler::encode_fs_path(path_str)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    Ok(FsRuleEntry {
+        unit,
+        rule: FsRule {
+            access,
+            reserved: [0; 3],
+            path: encoded,
+        },
     })
 }
 
@@ -438,10 +590,11 @@ mod tests {
         Cli, Commands, EventRecord, build_command, export_sarif, handle_init_with, handle_report,
         read_recent_events, run_command, setup_isolation,
     };
+    use bpf_api::{FS_READ, FS_WRITE};
     use clap::{CommandFactory, Parser};
     use policy_core::{ExecDefault, FsDefault, Mode, NetDefault, Policy};
     use serial_test::serial;
-    use std::ffi::OsStr;
+    use std::ffi::{OsStr, OsString};
     use std::fs::File;
     use std::io::{Cursor, Write};
     use std::path::{Path, PathBuf};
@@ -465,6 +618,35 @@ mod tests {
     impl Drop for DirGuard {
         fn drop(&mut self) {
             let _ = std::env::set_current_dir(&self.original);
+        }
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set_path(key: &'static str, value: &Path) -> Self {
+            let original = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.original {
+                unsafe {
+                    std::env::set_var(self.key, value);
+                }
+            } else {
+                unsafe {
+                    std::env::remove_var(self.key);
+                }
+            }
         }
     }
 
@@ -807,5 +989,83 @@ deny = ["execve"]
 
         let exec = exec_paths(&isolation.maps_layout);
         assert_eq!(exec, vec!["/bin/bash".to_string()]);
+    }
+
+    fn fs_rules(layout: &MapsLayout) -> Vec<(u32, PathBuf, u8)> {
+        layout
+            .fs_rules
+            .iter()
+            .map(|entry| {
+                let len = entry
+                    .rule
+                    .path
+                    .iter()
+                    .position(|&b| b == 0)
+                    .unwrap_or(entry.rule.path.len());
+                let path = std::str::from_utf8(&entry.rule.path[..len]).unwrap();
+                (entry.unit, PathBuf::from(path), entry.rule.access)
+            })
+            .collect()
+    }
+
+    #[test]
+    #[serial]
+    fn setup_isolation_adds_implicit_cargo_directories() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path().join("workspace");
+        let target = dir.path().join("target");
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        let _workspace_env = EnvGuard::set_path("CARGO_WORKSPACE_DIR", &workspace);
+        let _target_env = EnvGuard::set_path("CARGO_TARGET_DIR", &target);
+        let _out_env = EnvGuard::set_path("OUT_DIR", &out_dir);
+        let _guard = DirGuard::change_to(dir.path());
+
+        let isolation = setup_isolation(&[], &[]).unwrap();
+        let rules = fs_rules(&isolation.maps_layout);
+
+        assert!(rules.contains(&(0, workspace.clone(), FS_READ)));
+        assert!(rules.contains(&(0, target.clone(), FS_READ | FS_WRITE)));
+        assert!(rules.contains(&(0, out_dir.clone(), FS_READ | FS_WRITE)));
+    }
+
+    #[test]
+    #[serial]
+    fn setup_isolation_merges_duplicate_filesystem_rules() {
+        let dir = tempdir().unwrap();
+        let _guard = DirGuard::change_to(dir.path());
+
+        let workspace = dir.path().join("workspace");
+        let target = dir.path().join("target");
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::create_dir_all(&out_dir).unwrap();
+
+        std::fs::write(
+            "warden.toml",
+            format!(
+                "mode = \"enforce\"\nfs.default = \"strict\"\nnet.default = \"deny\"\nexec.default = \"allowlist\"\n\n[allow.fs]\nread_extra = [\"{}\"]\nwrite_extra = []\n",
+                target.to_str().unwrap(),
+            ),
+        )
+        .unwrap();
+
+        let _workspace_env = EnvGuard::set_path("CARGO_WORKSPACE_DIR", &workspace);
+        let _target_env = EnvGuard::set_path("CARGO_TARGET_DIR", &target);
+        let _out_env = EnvGuard::set_path("OUT_DIR", &out_dir);
+
+        let isolation = setup_isolation(&[], &[]).unwrap();
+        let rules = fs_rules(&isolation.maps_layout);
+
+        let target_rules: Vec<_> = rules
+            .iter()
+            .filter(|(unit, path, _)| *unit == 0 && path == &target)
+            .collect();
+        assert_eq!(target_rules.len(), 1);
+        assert_eq!(target_rules[0].2, FS_READ | FS_WRITE);
     }
 }

--- a/crates/policy-compiler/src/lib.rs
+++ b/crates/policy-compiler/src/lib.rs
@@ -154,7 +154,7 @@ fn encode_exec_path(path: &str) -> Result<[u8; 256], CompileError> {
     fill_path_bytes(path).ok_or_else(|| CompileError::ExecPathTooLong { path: path.into() })
 }
 
-fn encode_fs_path(path: &str) -> Result<[u8; 256], CompileError> {
+pub fn encode_fs_path(path: &str) -> Result<[u8; 256], CompileError> {
     fill_path_bytes(path).ok_or_else(|| CompileError::FsPathTooLong { path: path.into() })
 }
 


### PR DESCRIPTION
## Summary
- discover the Cargo workspace, target, and OUT_DIR directories during isolation setup and merge their implicit filesystem rules before populating the map layout
- add helpers that reuse the policy compiler path encoding and cover implicit allowances and deduplication with new tests
- expose the filesystem path encoder from the policy compiler and pull in cargo_metadata for workspace discovery

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
