### PR TITLE
Handle implicit Cargo filesystem allowances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,6 +336,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1219,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "aya",
+ "cargo_metadata",
  "clap",
  "libc",
  "libseccomp",
@@ -1424,19 +1457,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
+cargo_metadata = "0.18"
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/policy-compiler/src/lib.rs
+++ b/crates/policy-compiler/src/lib.rs
@@ -154,7 +154,7 @@ fn encode_exec_path(path: &str) -> Result<[u8; 256], CompileError> {
     fill_path_bytes(path).ok_or_else(|| CompileError::ExecPathTooLong { path: path.into() })
 }
 
-fn encode_fs_path(path: &str) -> Result<[u8; 256], CompileError> {
+pub fn encode_fs_path(path: &str) -> Result<[u8; 256], CompileError> {
     fill_path_bytes(path).ok_or_else(|| CompileError::FsPathTooLong { path: path.into() })
 }
 


### PR DESCRIPTION
## Summary
- discover Cargo workspace, target, and OUT_DIR directories during isolation setup and merge their implicit permissions with policy-provided filesystem rules before populating the maps layout
- reuse the policy compiler's filesystem path encoder when assembling merged rules and add regression tests that cover implicit directory injection, deduplication, and mode overrides
- expose `encode_fs_path` from the policy compiler and depend on `cargo_metadata` so the CLI can resolve workspace metadata when environment hints are absent

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

## Avatar
- Старший разработчик на Rust (Senior Rust Developer) — выбран для корректного согласования правил доступа к файловой системе с неявными директориями Cargo
