### PR TITLE
Add shared SARIF event reporting crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-reporting"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1158,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aya",
+ "event-reporting",
  "futures-core",
  "futures-util",
  "libc",
@@ -1156,7 +1166,6 @@ dependencies = [
  "prometheus",
  "prost",
  "qqrm-bpf-api",
- "serde",
  "serde_json",
  "serial_test",
  "systemd-journal-logger",
@@ -1188,6 +1197,7 @@ dependencies = [
  "assert_cmd",
  "aya",
  "clap",
+ "event-reporting",
  "libc",
  "libseccomp",
  "qqrm-agent-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ members = [
     "crates/testkits",
     "examples/network-build",
     "examples/spawn-bash",
+    "crates/event-reporting",
 ]
 resolver = "2"

--- a/crates/agent-lite/Cargo.toml
+++ b/crates/agent-lite/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../../README.md"
 [dependencies]
 aya = { version = "0.13" }
 bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+event-reporting = { version = "0.1.0", path = "../event-reporting" }
 
 anyhow = "1"
 log = "0.4"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
+event-reporting = { version = "0.1.0", path = "../event-reporting" }
 
 [dev-dependencies]
 serial_test = "3"

--- a/crates/event-reporting/Cargo.toml
+++ b/crates/event-reporting/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "event-reporting"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Shared event reporting utilities for the cargo-warden workspace."
+repository = "https://github.com/qqrm/cargo-warden"
+homepage = "https://github.com/qqrm/cargo-warden"
+documentation = "https://docs.rs/event-reporting"
+readme = "../../README.md"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/event-reporting/src/lib.rs
+++ b/crates/event-reporting/src/lib.rs
@@ -1,0 +1,113 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::fmt;
+use std::io;
+use std::path::Path;
+
+/// User-facing representation of an event emitted by the sandbox.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventRecord {
+    pub pid: u32,
+    pub unit: u8,
+    pub action: u8,
+    pub verdict: u8,
+    pub container_id: u64,
+    pub caps: u64,
+    pub path_or_addr: String,
+}
+
+impl fmt::Display for EventRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "pid={} unit={} action={} verdict={} container_id={} caps={} path_or_addr={}",
+            self.pid,
+            self.unit,
+            self.action,
+            self.verdict,
+            self.container_id,
+            self.caps,
+            self.path_or_addr
+        )
+    }
+}
+
+/// Builds a SARIF log from a slice of events.
+pub fn sarif_from_events(events: &[EventRecord]) -> serde_json::Value {
+    let results: Vec<_> = events
+        .iter()
+        .map(|e| {
+            json!({
+                "ruleId": e.action.to_string(),
+                "level": if e.verdict == 1 { "error" } else { "note" },
+                "message": { "text": format!("{}", e) },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": { "uri": e.path_or_addr }
+                    }
+                }]
+            })
+        })
+        .collect();
+    json!({
+        "version": "2.1.0",
+        "runs": [{
+            "tool": { "driver": { "name": "cargo-warden" } },
+            "results": results
+        }]
+    })
+}
+
+/// Writes a SARIF log to the given path.
+pub fn export_sarif(events: &[EventRecord], path: &Path) -> io::Result<()> {
+    let sarif = sarif_from_events(events);
+    let content = serde_json::to_string_pretty(&sarif).map_err(io::Error::other)?;
+    std::fs::write(path, content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use std::io::Read;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn sarif_contains_events() {
+        let records = vec![EventRecord {
+            pid: 42,
+            unit: 1,
+            action: 3,
+            verdict: 1,
+            container_id: 99,
+            caps: 0,
+            path_or_addr: "/bin/deny".into(),
+        }];
+        let sarif = sarif_from_events(&records);
+        assert_eq!(sarif["version"], "2.1.0");
+        assert_eq!(sarif["runs"][0]["results"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn export_writes_file() {
+        let record = EventRecord {
+            pid: 7,
+            unit: 1,
+            action: 3,
+            verdict: 1,
+            container_id: 5,
+            caps: 0,
+            path_or_addr: "/bin/bad".into(),
+        };
+        let tmp = NamedTempFile::new().unwrap();
+        export_sarif(std::slice::from_ref(&record), tmp.path()).unwrap();
+
+        let mut content = String::new();
+        File::open(tmp.path())
+            .unwrap()
+            .read_to_string(&mut content)
+            .unwrap();
+        assert!(content.contains("\"version\": \"2.1.0\""));
+        assert!(content.contains(&record.path_or_addr));
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `event-reporting` crate that defines `EventRecord`, `sarif_from_events`, and `export_sarif`
- refactor `qqrm-agent-lite` to re-export the shared event reporting utilities and convert BPF events with a helper
- update the CLI to import the shared types/functions instead of maintaining local duplicates

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

Avatar: Software Architect — selected because the task required reorganizing shared architecture across multiple crates.


------
https://chatgpt.com/codex/tasks/task_e_68cc17d9f0c483329dac907244b3e1c7