### PR TITLE
Store isolation mode in sandbox runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,10 +1201,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "event-reporting",
- "libc",
- "libseccomp",
  "qqrm-agent-lite",
- "qqrm-bpf-api",
  "qqrm-policy-compiler",
  "qqrm-policy-core",
  "qqrm-sandbox-runtime",
@@ -1249,6 +1246,7 @@ dependencies = [
  "qqrm-agent-lite",
  "qqrm-bpf-api",
  "qqrm-policy-compiler",
+ "qqrm-policy-core",
  "serde",
  "serde_json",
 ]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -74,7 +74,6 @@ enum Commands {
 }
 
 struct IsolationConfig {
-    #[cfg(test)]
     mode: Mode,
     syscall_deny: Vec<String>,
     maps_layout: MapsLayout,
@@ -127,7 +126,7 @@ fn handle_build(
     mode_override: Option<Mode>,
 ) -> io::Result<()> {
     let isolation = setup_isolation(allow, policy, mode_override)?;
-    let status = run_in_sandbox(build_command(&args), &isolation)?;
+    let status = run_in_sandbox(build_command(&args), isolation.mode, &isolation)?;
     if !status.success() {
         exit(status.code().unwrap_or(1));
     }
@@ -170,7 +169,6 @@ fn setup_isolation(
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
 
     Ok(IsolationConfig {
-        #[cfg(test)]
         mode: policy.mode,
         syscall_deny: policy.syscall_deny().cloned().collect(),
         maps_layout: layout,
@@ -291,7 +289,7 @@ fn handle_run(
         ));
     }
     let isolation = setup_isolation(allow, policy, mode_override)?;
-    let status = run_in_sandbox(run_command(&cmd), &isolation)?;
+    let status = run_in_sandbox(run_command(&cmd), isolation.mode, &isolation)?;
     if !status.success() {
         exit(status.code().unwrap_or(1));
     }
@@ -306,9 +304,18 @@ fn run_command(cmd: &[String]) -> Command {
     command
 }
 
-fn run_in_sandbox(command: Command, isolation: &IsolationConfig) -> io::Result<ExitStatus> {
+fn run_in_sandbox(
+    command: Command,
+    mode: Mode,
+    isolation: &IsolationConfig,
+) -> io::Result<ExitStatus> {
     let mut sandbox = Sandbox::new()?;
-    let run_result = sandbox.run(command, &isolation.syscall_deny, &isolation.maps_layout);
+    let run_result = sandbox.run(
+        command,
+        mode,
+        &isolation.syscall_deny,
+        &isolation.maps_layout,
+    );
     let shutdown_result = sandbox.shutdown();
     let status = match run_result {
         Ok(status) => status,
@@ -747,6 +754,7 @@ deny = ["execve"]
         let allow = vec!["/usr/bin/rustc".to_string(), "/usr/bin/git".to_string()];
         let isolation = setup_isolation(&allow, &paths, None).unwrap();
 
+        assert_eq!(isolation.mode, Mode::Enforce);
         assert!(isolation.syscall_deny.contains(&"clone".to_string()));
         assert!(isolation.syscall_deny.contains(&"execve".to_string()));
         assert_eq!(isolation.syscall_deny.len(), 2);
@@ -766,6 +774,7 @@ deny = ["execve"]
 
         let isolation = setup_isolation(&[], &[], None).unwrap();
 
+        assert_eq!(isolation.mode, Mode::Enforce);
         assert!(isolation.syscall_deny.is_empty());
         assert!(isolation.maps_layout.exec_allowlist.is_empty());
         assert!(isolation.maps_layout.net_rules.is_empty());
@@ -780,6 +789,7 @@ deny = ["execve"]
         let allow = vec!["/bin/bash".to_string()];
         let isolation = setup_isolation(&allow, &[], None).unwrap();
 
+        assert_eq!(isolation.mode, Mode::Enforce);
         let exec = exec_paths(&isolation.maps_layout);
         assert_eq!(exec, vec!["/bin/bash".to_string()]);
     }

--- a/crates/sandbox-runtime/Cargo.toml
+++ b/crates/sandbox-runtime/Cargo.toml
@@ -16,5 +16,6 @@ libc = "0.2"
 libseccomp = "0.3"
 qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
 qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
+policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -1,5 +1,6 @@
 use crate::layout::LayoutRecorder;
 use crate::util::{events_path, fake_cgroup_dir};
+use policy_core::Mode;
 use qqrm_policy_compiler::MapsLayout;
 use std::fs;
 use std::io;
@@ -40,6 +41,7 @@ impl FakeSandbox {
     pub(crate) fn run(
         &mut self,
         mut command: Command,
+        _mode: Mode,
         layout: &MapsLayout,
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {

--- a/crates/sandbox-runtime/src/real.rs
+++ b/crates/sandbox-runtime/src/real.rs
@@ -8,6 +8,7 @@ use aya::programs::cgroup_sock_addr::CgroupSockAddrLink;
 use aya::programs::lsm::LsmLink;
 use aya::programs::{CgroupAttachMode, CgroupSockAddr, Lsm};
 use aya::{Btf, Ebpf};
+use policy_core::Mode;
 use qqrm_policy_compiler::MapsLayout;
 use std::cell::UnsafeCell;
 use std::io;
@@ -50,6 +51,7 @@ impl RealSandbox {
     pub(crate) fn run(
         &self,
         command: Command,
+        _mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
     ) -> io::Result<ExitStatus> {

--- a/crates/sandbox-runtime/src/runtime.rs
+++ b/crates/sandbox-runtime/src/runtime.rs
@@ -1,5 +1,6 @@
 use crate::fake::FakeSandbox;
 use crate::real::RealSandbox;
+use policy_core::Mode;
 use qqrm_policy_compiler::MapsLayout;
 use std::env;
 use std::io;
@@ -36,12 +37,13 @@ impl Sandbox {
     pub fn run(
         &mut self,
         command: Command,
+        mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
     ) -> io::Result<ExitStatus> {
         match &mut self.inner {
-            SandboxImpl::Real(real) => real.run(command, deny, layout),
-            SandboxImpl::Fake(fake) => fake.run(command, layout),
+            SandboxImpl::Real(real) => real.run(command, mode, deny, layout),
+            SandboxImpl::Fake(fake) => fake.run(command, mode, layout),
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep the resolved policy mode inside IsolationConfig and use it when invoking the sandbox. F:crates/cli/src/main.rs#L76-L329
- Thread Mode through Sandbox::run and its real and fake implementations. F:crates/sandbox-runtime/src/runtime.rs#L1-L47 F:crates/sandbox-runtime/src/real.rs#L1-L58 F:crates/sandbox-runtime/src/fake.rs#L1-L50
- Extend CLI isolation tests to assert the default mode behavior. F:crates/cli/src/main.rs#L753-L820

Avatar: Selected **senior_developer** because the cross-crate Rust refactor needed seasoned expertise with CLI and runtime coordination.

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test *(fails: system linker cannot find libseccomp)*
- cargo machete
