### PR TITLE
Add mode flag map wiring for sandbox runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "clap",
  "event-reporting",
  "qqrm-agent-lite",
+ "qqrm-bpf-api",
  "qqrm-policy-compiler",
  "qqrm-policy-core",
  "qqrm-sandbox-runtime",

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -17,6 +17,12 @@ pub const FS_RULES_CAPACITY: u32 = 256;
 pub const EVENT_RINGBUF_CAPACITY_BYTES: u32 = 4096;
 /// Number of slots tracked for emitted event counters.
 pub const EVENT_COUNT_SLOTS: u32 = 1;
+/// Number of entries in the mode flags map.
+pub const MODE_FLAGS_CAPACITY: u32 = 1;
+/// Flag value stored in the mode map when running in observe mode.
+pub const MODE_FLAG_OBSERVE: u32 = 0;
+/// Flag value stored in the mode map when running in enforce mode.
+pub const MODE_FLAG_ENFORCE: u32 = 1;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -71,6 +71,10 @@ type LengthMap = TestArray<u32, 1>;
 type EventCountsMap = Array<u64>;
 #[cfg(any(test, feature = "fuzzing"))]
 type EventCountsMap = TestArray<u64, { bpf_api::EVENT_COUNT_SLOTS as usize }>;
+#[cfg(target_arch = "bpf")]
+type ModeFlagsMap = Array<u32>;
+#[cfg(any(test, feature = "fuzzing"))]
+type ModeFlagsMap = TestArray<u32, { bpf_api::MODE_FLAGS_CAPACITY as usize }>;
 
 #[cfg(target_arch = "bpf")]
 type EventsMap = RingBuf;
@@ -148,6 +152,16 @@ const fn event_counts_map() -> EventCountsMap {
 }
 
 #[cfg(target_arch = "bpf")]
+const fn mode_flags_map() -> ModeFlagsMap {
+    Array::with_max_entries(bpf_api::MODE_FLAGS_CAPACITY, 0)
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const fn mode_flags_map() -> ModeFlagsMap {
+    TestArray::new()
+}
+
+#[cfg(target_arch = "bpf")]
 #[map(name = "EXEC_ALLOWLIST")]
 static mut EXEC_ALLOWLIST: ExecAllowlistMap = exec_allowlist_map();
 
@@ -202,6 +216,13 @@ static mut EVENT_COUNTS: EventCountsMap = event_counts_map();
 
 #[cfg(any(test, feature = "fuzzing"))]
 static EVENT_COUNTS: EventCountsMap = event_counts_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "MODE_FLAGS")]
+static mut MODE_FLAGS: ModeFlagsMap = mode_flags_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static MODE_FLAGS: ModeFlagsMap = mode_flags_map();
 
 #[cfg(target_arch = "bpf")]
 #[map(name = "FS_RULES")]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ event-reporting = { version = "0.1.0", path = "../event-reporting" }
 serial_test = "3"
 assert_cmd = "2"
 tempfile = "3"
+bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
 
 [[bin]]
 name = "cargo-warden"

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use bpf_api::MODE_FLAG_ENFORCE;
 use sandbox_runtime::LayoutSnapshot;
 use std::fs;
 use tempfile::tempdir;
@@ -61,6 +62,8 @@ read_extra = ["/etc/ssl/certs"]
     );
     let snapshot = snapshots.last().unwrap();
 
+    assert_eq!(snapshot.mode, "enforce");
+    assert_eq!(snapshot.mode_flag, Some(MODE_FLAG_ENFORCE));
     assert!(
         snapshot.exec.iter().any(|path| path == "/bin/echo"),
         "expected exec allowlist entry for /bin/echo: {:?}",

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -41,12 +41,12 @@ impl FakeSandbox {
     pub(crate) fn run(
         &mut self,
         mut command: Command,
-        _mode: Mode,
+        mode: Mode,
         _deny: &[String],
         layout: &MapsLayout,
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {
-            recorder.record(layout)?;
+            recorder.record(layout, mode)?;
         }
         command.status()
     }


### PR DESCRIPTION
## Summary
- add observe/enforce mode flag constants to the shared API and expose a dedicated MODE_FLAGS map in the BPF program so runtime code can configure it【F:crates/bpf-api/src/lib.rs#L20-L25】【F:crates/bpf-core/src/lib.rs#L75-L160】【F:crates/bpf-core/src/lib.rs#L213-L218】
- extend `MapsLayout` to serialize the policy mode flag and cover it with new assertions and unit tests【F:crates/policy-compiler/src/lib.rs#L6-L87】【F:crates/policy-compiler/src/lib.rs#L200-L289】
- write the mode flag before launching the sandboxed process, record the chosen mode in fake snapshots, and update the CLI integration test to verify it【F:crates/sandbox-runtime/src/maps.rs#L1-L57】【F:crates/sandbox-runtime/src/real.rs#L51-L156】【F:crates/sandbox-runtime/src/layout.rs#L32-L156】【F:crates/sandbox-runtime/src/fake.rs#L41-L50】【F:crates/cli/tests/sandbox.rs#L1-L100】

Avatar: `tech_lead` — coordinating the kernel/BPF plumbing and policy surface required senior technical oversight.

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete` *(reports existing unused dependencies in the CLI crate)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd7dc4d308332868bef6ebcf526c7