### PR TITLE
Restrict sandbox to allowed environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,7 +998,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -1201,6 +1219,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "event-reporting",
+ "predicates",
  "qqrm-agent-lite",
  "qqrm-bpf-api",
  "qqrm-policy-compiler",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,6 +26,7 @@ serial_test = "3"
 assert_cmd = "2"
 tempfile = "3"
 bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
+predicates = "3"
 
 [[bin]]
 name = "cargo-warden"

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -1,5 +1,5 @@
 use crate::layout::LayoutRecorder;
-use crate::util::{events_path, fake_cgroup_dir};
+use crate::util::{events_path, fake_cgroup_dir, filter_environment};
 use policy_core::Mode;
 use qqrm_policy_compiler::MapsLayout;
 use std::fs;
@@ -44,10 +44,14 @@ impl FakeSandbox {
         mode: Mode,
         _deny: &[String],
         layout: &MapsLayout,
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {
             recorder.record(layout, mode)?;
         }
+        let filtered_env = filter_environment(allowed_env);
+        command.env_clear();
+        command.envs(filtered_env);
         command.status()
     }
 

--- a/crates/sandbox-runtime/src/runtime.rs
+++ b/crates/sandbox-runtime/src/runtime.rs
@@ -40,10 +40,11 @@ impl Sandbox {
         mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         match &mut self.inner {
-            SandboxImpl::Real(real) => real.run(command, mode, deny, layout),
-            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout),
+            SandboxImpl::Real(real) => real.run(command, mode, deny, layout, allowed_env),
+            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout, allowed_env),
         }
     }
 

--- a/crates/sandbox-runtime/src/util.rs
+++ b/crates/sandbox-runtime/src/util.rs
@@ -1,4 +1,6 @@
+use std::collections::HashSet;
 use std::env;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -7,6 +9,7 @@ pub(crate) const EVENTS_PATH_ENV: &str = "QQRM_WARDEN_EVENTS_PATH";
 pub(crate) const FAKE_CGROUP_DIR_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_DIR";
 pub(crate) const FAKE_CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_ROOT";
 pub(crate) const CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_CGROUP_ROOT";
+pub(crate) const ESSENTIAL_ENV_VARS: &[&str] = &["PATH"];
 
 pub(crate) fn events_path() -> PathBuf {
     if let Some(path) = env::var_os(EVENTS_PATH_ENV) {
@@ -42,4 +45,17 @@ pub(crate) fn unique_suffix() -> u128 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_micros())
         .unwrap_or(0)
+}
+
+pub(crate) fn filter_environment(allowed: &[String]) -> Vec<(OsString, OsString)> {
+    let mut allowed_names: HashSet<String> = allowed.iter().cloned().collect();
+    allowed_names.extend(ESSENTIAL_ENV_VARS.iter().map(|name| (*name).to_string()));
+
+    env::vars_os()
+        .filter(|(key, _)| {
+            key.to_str()
+                .map(|name| allowed_names.contains(name))
+                .unwrap_or(false)
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary
- Surface allowed environment variables from policy compilation alongside the maps layout.
- Pass the permitted environment list through the CLI into both real and fake sandbox runtimes and filter child environments to defaults plus policy entries.
- Extend integration coverage to assert that only allowed environment variables are visible to sandboxed commands.

## Testing
- 
-  *(fails: duplicate ModeFlagsMap definition in qqrm-bpf-core)*
- 
-  *(fails: duplicate ModeFlagsMap definition in qqrm-bpf-core)*
-  *(fails: linker cannot find libseccomp)*
- cargo-machete found the following unused dependencies in this directory:
qqrm-cargo-warden -- ./crates/cli/Cargo.toml:
	qqrm-agent-lite
	serde

If you believe cargo-machete has detected an unused dependency incorrectly,
you can add the dependency to the list of dependencies to ignore in the
`[package.metadata.cargo-machete]` section of the appropriate Cargo.toml.
For example:

[package.metadata.cargo-machete]
ignored = ["prost"]

You can also try running it with the `--with-metadata` flag for better accuracy,
though this may modify your Cargo.lock files.

## Avatar
- Security Engineer (https://qqrm.github.io/avatars-mcp/#security) — chosen to focus on hardening sandbox exposure by constraining process environments.