### PR TITLE
Support workspace policy overrides in CLI

### DIFF
--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -2,7 +2,17 @@ use assert_cmd::Command;
 use bpf_api::MODE_FLAG_ENFORCE;
 use sandbox_runtime::LayoutSnapshot;
 use std::fs;
+use std::path::Path;
 use tempfile::tempdir;
+
+fn read_snapshots(path: &Path) -> Result<Vec<LayoutSnapshot>, Box<dyn std::error::Error>> {
+    let layout_contents = fs::read_to_string(path)?;
+    let snapshots = layout_contents
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<Vec<LayoutSnapshot>, _>>()?;
+    Ok(snapshots)
+}
 
 #[test]
 fn run_fake_sandbox_records_layout() -> Result<(), Box<dyn std::error::Error>> {
@@ -50,11 +60,7 @@ read_extra = ["/etc/ssl/certs"]
         .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path);
     cmd.assert().success();
 
-    let layout_contents = fs::read_to_string(&layout_path)?;
-    let snapshots: Vec<LayoutSnapshot> = layout_contents
-        .lines()
-        .map(serde_json::from_str)
-        .collect::<Result<_, _>>()?;
+    let snapshots = read_snapshots(&layout_path)?;
     assert!(
         !snapshots.is_empty(),
         "expected at least one layout snapshot in {}",
@@ -110,5 +116,157 @@ read_extra = ["/etc/ssl/certs"]
         "expected fake cgroup removal: {}",
         cgroup_path.display()
     );
+    Ok(())
+}
+
+#[test]
+fn workspace_policy_overrides_modify_layout() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let workspace_root = dir.path();
+    let events_a = workspace_root.join("alpha-events.jsonl");
+    let layout_a = workspace_root.join("alpha-layout.jsonl");
+    let cgroup_a = workspace_root.join("alpha-cgroup");
+    let events_b = workspace_root.join("beta-events.jsonl");
+    let layout_b = workspace_root.join("beta-layout.jsonl");
+    let cgroup_b = workspace_root.join("beta-cgroup");
+
+    fs::create_dir_all(workspace_root.join("members/alpha/src"))?;
+    fs::create_dir_all(workspace_root.join("members/beta/src"))?;
+
+    fs::write(
+        workspace_root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["members/alpha", "members/beta"]
+"#,
+    )?;
+
+    fs::write(
+        workspace_root.join("members/alpha/Cargo.toml"),
+        r#"[package]
+name = "alpha"
+version = "0.1.0"
+edition = "2024"
+"#,
+    )?;
+    fs::write(
+        workspace_root.join("members/alpha/src/lib.rs"),
+        "pub fn alpha() {}\n",
+    )?;
+
+    fs::write(
+        workspace_root.join("members/beta/Cargo.toml"),
+        r#"[package]
+name = "beta"
+version = "0.1.0"
+edition = "2024"
+"#,
+    )?;
+    fs::write(
+        workspace_root.join("members/beta/src/lib.rs"),
+        "pub fn beta() {}\n",
+    )?;
+
+    fs::write(
+        workspace_root.join("workspace.warden.toml"),
+        r#"[root]
+mode = "enforce"
+
+[root.exec]
+default = "allowlist"
+
+[root.net]
+default = "deny"
+
+[root.allow.exec]
+allowed = []
+
+[root.allow.net]
+hosts = []
+
+[root.allow.fs]
+write_extra = []
+read_extra = []
+
+[members.alpha.allow.exec]
+allowed = ["/usr/bin/member-a"]
+
+[members.beta.exec]
+default = "allow"
+
+[members.beta.allow.exec]
+allowed = []
+
+[members.beta.allow.net]
+hosts = ["10.0.0.1:1234"]
+"#,
+    )?;
+
+    let alpha_dir = workspace_root.join("members/alpha");
+    let mut cmd = Command::cargo_bin("cargo-warden")?;
+    cmd.arg("run")
+        .arg("--")
+        .arg("true")
+        .current_dir(&alpha_dir)
+        .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
+        .env("QQRM_WARDEN_EVENTS_PATH", &events_a)
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_a)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_a);
+    cmd.assert().success();
+
+    let alpha_snapshots = read_snapshots(&layout_a)?;
+    let alpha_snapshot = alpha_snapshots.last().expect("alpha snapshot present");
+    assert!(
+        alpha_snapshot
+            .exec
+            .iter()
+            .any(|path| path == "/usr/bin/member-a"),
+        "expected per-member exec allowance for alpha: {:?}",
+        alpha_snapshot.exec
+    );
+    assert!(
+        alpha_snapshot
+            .net
+            .iter()
+            .all(|rule| !(rule.addr == "10.0.0.1" && rule.port == 1234)),
+        "alpha overrides should not include beta network host: {:?}",
+        alpha_snapshot.net
+    );
+
+    let mut cmd = Command::cargo_bin("cargo-warden")?;
+    cmd.arg("run")
+        .arg("--")
+        .arg("true")
+        .current_dir(workspace_root)
+        .env("CARGO_PRIMARY_PACKAGE", "beta")
+        .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
+        .env("QQRM_WARDEN_EVENTS_PATH", &events_b)
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_b)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_b);
+    cmd.assert().success();
+
+    let beta_snapshots = read_snapshots(&layout_b)?;
+    let beta_snapshot = beta_snapshots.last().expect("beta snapshot present");
+    assert!(
+        !beta_snapshot
+            .exec
+            .iter()
+            .any(|path| path == "/usr/bin/member-a"),
+        "beta overrides should not inherit alpha exec allowlist: {:?}",
+        beta_snapshot.exec
+    );
+    assert!(
+        beta_snapshot
+            .net
+            .iter()
+            .any(|rule| rule.addr == "10.0.0.1" && rule.port == 1234),
+        "beta overrides should include network host 10.0.0.1:1234: {:?}",
+        beta_snapshot.net
+    );
+
+    assert!(
+        !cgroup_a.exists() && !cgroup_b.exists(),
+        "fake sandbox should remove cgroup directories"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
- load workspace-level policies from `workspace.warden.toml`, detect the active member via cargo metadata or environment hints, and compile the effective policy before launching the sandbox
- factor a layout snapshot reader and add multi-member fake sandbox coverage to confirm per-member overrides adjust the recorded permissions
- Avatar: `senior_developer` — selected for its experience delivering reliable Rust features and coordinating policy plumbing

## Testing
- cargo fmt --all
- cargo check --tests --benches *(fails: `ModeFlagsMap` is defined multiple times in `crates/bpf-core/src/lib.rs`)*
- cargo clippy --all-targets --all-features -- -D warnings *(fails: same duplicate `ModeFlagsMap` definition)*
- cargo test *(fails: duplicate `ModeFlagsMap` definition and missing `libseccomp` while linking sandbox runtime)*
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cce997aa208332aa18c0414fa7c09c