### PR TITLE
Add observe mode sandbox test

### DIFF
--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -112,3 +112,107 @@ read_extra = ["/etc/ssl/certs"]
     );
     Ok(())
 }
+
+#[test]
+fn observe_mode_records_denied_event() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let events_path = dir.path().join("warden-events.jsonl");
+    let layout_path = dir.path().join("fake-layout.jsonl");
+    let cgroup_path = dir.path().join("fake-cgroup");
+    let policy_path = dir.path().join("policy.toml");
+    let forbidden_path = dir.path().join("classified.txt");
+
+    fs::write(&forbidden_path, "restricted")?;
+    fs::write(
+        &policy_path,
+        r#"
+mode = "enforce"
+
+[fs]
+default = "strict"
+
+[net]
+default = "deny"
+
+[exec]
+default = "allowlist"
+
+[allow.exec]
+allowed = ["/bin/sh", "/bin/cat"]
+
+[allow.fs]
+write_extra = []
+read_extra = []
+"#,
+    )?;
+
+    let expected_path = forbidden_path.display().to_string();
+
+    let mut cmd = Command::cargo_bin("cargo-warden")?;
+    cmd.arg("run")
+        .arg("--mode")
+        .arg("observe")
+        .arg("--allow")
+        .arg("/bin/sh")
+        .arg("--allow")
+        .arg("/bin/cat")
+        .arg("--policy")
+        .arg(&policy_path)
+        .arg("--")
+        .arg("/bin/sh")
+        .arg("-c")
+        .arg(format!("cat {}", forbidden_path.display()))
+        .current_dir(dir.path())
+        .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
+        .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path)
+        .env("QQRM_WARDEN_FAKE_DENIED_PATH", &forbidden_path);
+    cmd.assert().success();
+
+    let layout_contents = fs::read_to_string(&layout_path)?;
+    let snapshots: Vec<LayoutSnapshot> = layout_contents
+        .lines()
+        .map(serde_json::from_str)
+        .collect::<Result<_, _>>()?;
+    assert!(
+        !snapshots.is_empty(),
+        "expected at least one layout snapshot in {}",
+        layout_path.display()
+    );
+    let snapshot = snapshots.last().unwrap();
+    assert_eq!(snapshot.mode, "observe");
+
+    let events_contents = fs::read_to_string(&events_path)?;
+    let mut found_denied = false;
+    for line in events_contents.lines() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let path = value
+            .get("path_or_addr")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        if path != expected_path {
+            continue;
+        }
+        let verdict = value.get("verdict").and_then(|v| v.as_u64());
+        assert_eq!(verdict, Some(1), "expected deny verdict for {value}");
+        let observe_flag = value.get("observe").and_then(|v| v.as_bool());
+        assert_eq!(
+            observe_flag,
+            Some(true),
+            "expected observe flag for {value}"
+        );
+        found_denied = true;
+        break;
+    }
+    assert!(
+        found_denied,
+        "expected denied event for {} in {}: {events_contents}",
+        expected_path,
+        events_path.display()
+    );
+
+    Ok(())
+}

--- a/crates/sandbox-runtime/src/util.rs
+++ b/crates/sandbox-runtime/src/util.rs
@@ -7,6 +7,7 @@ pub(crate) const EVENTS_PATH_ENV: &str = "QQRM_WARDEN_EVENTS_PATH";
 pub(crate) const FAKE_CGROUP_DIR_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_DIR";
 pub(crate) const FAKE_CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_ROOT";
 pub(crate) const CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_CGROUP_ROOT";
+pub(crate) const FAKE_DENIED_PATH_ENV: &str = "QQRM_WARDEN_FAKE_DENIED_PATH";
 
 pub(crate) fn events_path() -> PathBuf {
     if let Some(path) = env::var_os(EVENTS_PATH_ENV) {


### PR DESCRIPTION
## Summary
- extend the fake sandbox runtime to record denied file events (including mode metadata) when the fake path environment is set
- add an integration test that runs `cargo-warden run --mode observe` against a strict policy and verifies the fake event log captures a denied path

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches` *(fails: duplicate `ModeFlagsMap` type definitions in `crates/bpf-core/src/lib.rs` on the current main branch)*
- `cargo check -p qqrm-cargo-warden --tests`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: duplicate `ModeFlagsMap` type definitions in `crates/bpf-core/src/lib.rs`)*
- `cargo test` *(fails: duplicate `ModeFlagsMap` type definitions in `crates/bpf-core/src/lib.rs`)*
- `cargo test -p qqrm-cargo-warden --test sandbox`
- `cargo machete`

## Avatar
- Automated Test Engineer (tester) — chosen to emphasize the addition of observe-mode regression coverage and validation tooling.


------
https://chatgpt.com/codex/tasks/task_e_68cce95c9a148332b1abb6d4c70c6659