### PR TITLE
Gate seccomp setup on enforce mode

### DIFF
--- a/crates/sandbox-runtime/src/seccomp.rs
+++ b/crates/sandbox-runtime/src/seccomp.rs
@@ -1,7 +1,11 @@
+use policy_core::Mode;
 use std::io;
 
 #[cfg(not(test))]
-pub(crate) fn apply_seccomp(deny: &[String]) -> io::Result<()> {
+pub(crate) fn apply_seccomp(mode: Mode, deny: &[String]) -> io::Result<()> {
+    if !matches!(mode, Mode::Enforce) {
+        return Ok(());
+    }
     use libseccomp::{ScmpAction, ScmpFilterContext, ScmpSyscall};
     let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow).map_err(io::Error::other)?;
     for name in deny {
@@ -15,6 +19,6 @@ pub(crate) fn apply_seccomp(deny: &[String]) -> io::Result<()> {
 }
 
 #[cfg(test)]
-pub(crate) fn apply_seccomp(_deny: &[String]) -> io::Result<()> {
+pub(crate) fn apply_seccomp(_mode: Mode, _deny: &[String]) -> io::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add the sandbox mode argument to `apply_seccomp` and skip installing filters outside enforce mode `F:crates/sandbox-runtime/src/seccomp.rs#L1-L24`
- gate the real sandbox pre-exec hook behind the mode-aware helper and cover observe/enforce combinations with unit tests `F:crates/sandbox-runtime/src/real.rs#L138-L211`

## Testing
- `cargo fmt --all`
- `cargo check --tests --benches` *(fails: duplicate `ModeFlagsMap` definitions in `qqrm-bpf-core` tests)*
- `cargo check --tests --benches -p qqrm-sandbox-runtime`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: duplicate `ModeFlagsMap` definitions when compiling `qqrm-bpf-core` tests)*
- `cargo clippy -p qqrm-sandbox-runtime --all-targets -- -D warnings`
- `cargo test` *(fails: duplicate `ModeFlagsMap` definitions and missing system `libseccomp` when linking workspace tests)*
- `cargo test -p qqrm-sandbox-runtime`
- `cargo machete` *(reports pre-existing unused dependencies in `crates/cli`)*

## Avatar
- Security Engineer – chosen because the task hardens seccomp handling and needs a security-focused perspective.


------
https://chatgpt.com/codex/tasks/task_e_68cce9582b988332a8e8455335cc216a