### PR TITLE
Add compiled policy result with environment allowlist

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use event_reporting::{EventRecord, export_sarif};
 use policy_core::{ExecDefault, FsDefault, Mode, NetDefault, Permission, Policy, WorkspacePolicy};
-use qqrm_policy_compiler::{self, MapsLayout};
+use qqrm_policy_compiler::{self, CompiledPolicy, MapsLayout};
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::ffi::OsString;
@@ -167,13 +167,14 @@ fn setup_isolation(
         eprintln!("warning: {warn}");
     }
 
-    let layout = qqrm_policy_compiler::compile(&policy)
+    let compiled = qqrm_policy_compiler::compile(&policy)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let CompiledPolicy { maps_layout, .. } = compiled;
 
     Ok(IsolationConfig {
         mode: policy.mode,
         syscall_deny: policy.syscall_deny().cloned().collect(),
-        maps_layout: layout,
+        maps_layout,
     })
 }
 


### PR DESCRIPTION
## Summary
- add a `CompiledPolicy` result type that wraps the map layout and a sorted, deduplicated list of environment variables read by the policy
- update the compiler tests to assert both the serialized layout contents and the new environment allowlist
- adjust the CLI isolation setup to unpack the new compilation result while preserving existing behaviour

## Testing
- `cargo fmt -p qqrm-policy-compiler -p qqrm-cargo-warden`
- `cargo check -p qqrm-policy-compiler -p qqrm-cargo-warden`
- `cargo check -p qqrm-policy-compiler`
- `cargo clippy -p qqrm-policy-compiler -p qqrm-cargo-warden -- -D warnings`
- `cargo test -p qqrm-policy-compiler`
- `cargo machete`
- `cargo fmt` *(fails: rustfmt parse error in crates/bpf-core/src/lib.rs unrelated to this change)*
- `cargo check` *(fails: qqrm-bpf-core does not compile on host toolchain prior to this change)*
- `cargo test -p qqrm-cargo-warden` *(fails: missing system library libseccomp during linking)*

Avatar: Senior Rust Developer — best suited for designing and refactoring Rust features while keeping test coverage high.

------
https://chatgpt.com/codex/tasks/task_e_68cd4299f70083328eec1d2f518364d9