### PR TITLE
Propagate environment allowlists to the sandbox runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,7 +998,10 @@ checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]
@@ -1201,6 +1219,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "event-reporting",
+ "predicates",
  "qqrm-bpf-api",
  "qqrm-policy-compiler",
  "qqrm-policy-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,6 @@ dependencies = [
  "assert_cmd",
  "clap",
  "event-reporting",
- "qqrm-agent-lite",
  "qqrm-bpf-api",
  "qqrm-policy-compiler",
  "qqrm-policy-core",

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -391,52 +391,6 @@ static mut EVENTS: EventsMap = events_map();
 static EVENTS: EventsMap = events_map();
 
 #[cfg(target_arch = "bpf")]
-    NET_RULES.get(index)
-}
-
-#[cfg(target_arch = "bpf")]
-unsafe fn load_net_parent(index: u32) -> Option<bpf_api::NetParentEntry> {
-    NET_PARENTS.get(index).copied()
-}
-
-#[cfg(any(test, feature = "fuzzing"))]
-unsafe fn load_net_parent(index: u32) -> Option<bpf_api::NetParentEntry> {
-    NET_PARENTS.get(index)
-}
-
-#[cfg(target_arch = "bpf")]
-unsafe fn load_fs_rule(index: u32) -> Option<bpf_api::FsRuleEntry> {
-    FS_RULES.get(index).copied()
-}
-
-#[cfg(any(test, feature = "fuzzing"))]
-unsafe fn load_fs_rule(index: u32) -> Option<bpf_api::FsRuleEntry> {
-    FS_RULES.get(index)
-}
-=======
-#[map(name = "EVENT_COUNTS")]
-static mut EVENT_COUNTS: EventCountsMap = event_counts_map();
-
-#[cfg(any(test, feature = "fuzzing"))]
-static EVENT_COUNTS: EventCountsMap = event_counts_map();
-
-#[cfg(target_arch = "bpf")]
-#[map(name = "MODE_FLAGS")]
-static mut MODE_FLAGS: ModeFlagsMap = mode_flags_map();
-
-#[cfg(any(test, feature = "fuzzing"))]
-static MODE_FLAGS: ModeFlagsMap = mode_flags_map();
-
-#[cfg(target_arch = "bpf")]
-#[map(name = "FS_RULES")]
-static mut FS_RULES: FsRulesMap = fs_rules_ 
-#[cfg(any(test, feature = "fuzzing"))]
-static FS_RULES: FsRulesMap = fs_rules_map();
-
-#[cfg(target_arch = "bpf")]
-#[map(name
-
-#[cfg(target_arch = "bpf")]
 unsafe fn load_mode_flags() -> u32 {
     MODE_FLAGS.get(0).copied().unwrap_or(0)
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,6 @@ sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
 event-reporting = { version = "0.1.0", path = "../event-reporting" }
 
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ serial_test = "3"
 assert_cmd = "2"
 tempfile = "3"
 bpf-api = { package = "qqrm-bpf-api", path = "../bpf-api" }
+predicates = "3"
 
 [[bin]]
 name = "cargo-warden"

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use bpf_api::MODE_FLAG_ENFORCE;
+use predicates::prelude::*;
 use sandbox_runtime::LayoutSnapshot;
 use std::fs;
 use std::path::Path;
@@ -267,6 +268,59 @@ hosts = ["10.0.0.1:1234"]
         !cgroup_a.exists() && !cgroup_b.exists(),
         "fake sandbox should remove cgroup directories"
     );
+
+    Ok(())
+}
+
+#[test]
+fn run_filters_environment_variables() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let events_path = dir.path().join("warden-events.jsonl");
+    let cgroup_path = dir.path().join("fake-cgroup");
+    let layout_path = dir.path().join("fake-layout.jsonl");
+    let policy_path = dir.path().join("policy.toml");
+
+    fs::write(
+        &policy_path,
+        r#"mode = "enforce"
+
+[fs]
+default = "strict"
+
+[net]
+default = "deny"
+
+[exec]
+default = "allowlist"
+
+[allow.exec]
+allowed = ["/usr/bin/env"]
+
+[allow.env]
+read = ["ALLOWED_VAR"]
+"#,
+    )?;
+
+    let mut cmd = Command::cargo_bin("cargo-warden")?;
+    cmd.arg("run")
+        .arg("--policy")
+        .arg(&policy_path)
+        .arg("--")
+        .arg("/usr/bin/env")
+        .current_dir(dir.path())
+        .env("QQRM_WARDEN_FAKE_SANDBOX", "1")
+        .env("QQRM_WARDEN_EVENTS_PATH", &events_path)
+        .env("QQRM_WARDEN_FAKE_CGROUP_DIR", &cgroup_path)
+        .env("QQRM_WARDEN_FAKE_LAYOUT_PATH", &layout_path)
+        .env("ALLOWED_VAR", "visible")
+        .env("SECRET_VAR", "hidden");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("ALLOWED_VAR=visible"))
+        .stdout(predicate::str::contains("PATH="))
+        .stdout(predicate::str::contains("SECRET_VAR=").not())
+        .stdout(predicate::str::contains("QQRM_WARDEN_FAKE_SANDBOX=").not());
 
     Ok(())
 }

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -1,5 +1,5 @@
 use crate::layout::LayoutRecorder;
-use crate::util::{events_path, fake_cgroup_dir};
+use crate::util::{events_path, fake_cgroup_dir, filter_environment};
 use policy_core::Mode;
 use qqrm_policy_compiler::MapsLayout;
 use std::fs;
@@ -44,11 +44,14 @@ impl FakeSandbox {
         mode: Mode,
         _deny: &[String],
         layout: &MapsLayout,
-        _allowed_env_vars: &[String],
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {
             recorder.record(layout, mode)?;
         }
+        let filtered_env = filter_environment(allowed_env);
+        command.env_clear();
+        command.envs(filtered_env);
         command.status()
     }
 

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -44,6 +44,7 @@ impl FakeSandbox {
         mode: Mode,
         _deny: &[String],
         layout: &MapsLayout,
+        _allowed_env_vars: &[String],
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {
             recorder.record(layout, mode)?;

--- a/crates/sandbox-runtime/src/real.rs
+++ b/crates/sandbox-runtime/src/real.rs
@@ -54,9 +54,10 @@ impl RealSandbox {
         mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
+        allowed_env_vars: &[String],
     ) -> io::Result<ExitStatus> {
         let mut command = command;
-        self.install_pre_exec(&mut command, deny, layout.clone(), mode)?;
+        self.install_pre_exec(&mut command, deny, layout.clone(), mode, allowed_env_vars)?;
         let mut child = command.spawn()?;
         child.wait()
     }
@@ -141,6 +142,7 @@ impl RealSandbox {
         deny: &[String],
         layout: MapsLayout,
         mode: Mode,
+        _allowed_env_vars: &[String],
     ) -> io::Result<()> {
         let procs_fd = self.cgroup.procs_fd_raw()?;
         let rules = deny.to_vec();

--- a/crates/sandbox-runtime/src/runtime.rs
+++ b/crates/sandbox-runtime/src/runtime.rs
@@ -32,20 +32,19 @@ impl Sandbox {
         }
     }
 
-    /// Runs a command inside the sandbox, applying syscall deny rules,
-    /// populating BPF maps from the provided layout, and configuring allowed
-    /// environment variables.
+    /// Runs a command inside the sandbox, applying syscall deny rules and
+    /// populating BPF maps from the provided layout.
     pub fn run(
         &mut self,
         command: Command,
         mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
-        allowed_env_vars: &[String],
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         match &mut self.inner {
-            SandboxImpl::Real(real) => real.run(command, mode, deny, layout, allowed_env_vars),
-            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout, allowed_env_vars),
+            SandboxImpl::Real(real) => real.run(command, mode, deny, layout, allowed_env),
+            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout, allowed_env),
         }
     }
 

--- a/crates/sandbox-runtime/src/runtime.rs
+++ b/crates/sandbox-runtime/src/runtime.rs
@@ -32,18 +32,20 @@ impl Sandbox {
         }
     }
 
-    /// Runs a command inside the sandbox, applying syscall deny rules and
-    /// populating BPF maps from the provided layout.
+    /// Runs a command inside the sandbox, applying syscall deny rules,
+    /// populating BPF maps from the provided layout, and configuring allowed
+    /// environment variables.
     pub fn run(
         &mut self,
         command: Command,
         mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
+        allowed_env_vars: &[String],
     ) -> io::Result<ExitStatus> {
         match &mut self.inner {
-            SandboxImpl::Real(real) => real.run(command, mode, deny, layout),
-            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout),
+            SandboxImpl::Real(real) => real.run(command, mode, deny, layout, allowed_env_vars),
+            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout, allowed_env_vars),
         }
     }
 

--- a/crates/sandbox-runtime/src/util.rs
+++ b/crates/sandbox-runtime/src/util.rs
@@ -1,4 +1,6 @@
+use std::collections::HashSet;
 use std::env;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -7,6 +9,7 @@ pub(crate) const EVENTS_PATH_ENV: &str = "QQRM_WARDEN_EVENTS_PATH";
 pub(crate) const FAKE_CGROUP_DIR_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_DIR";
 pub(crate) const FAKE_CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_FAKE_CGROUP_ROOT";
 pub(crate) const CGROUP_ROOT_ENV: &str = "QQRM_WARDEN_CGROUP_ROOT";
+pub(crate) const ESSENTIAL_ENV_VARS: &[&str] = &["PATH"];
 
 pub(crate) fn events_path() -> PathBuf {
     if let Some(path) = env::var_os(EVENTS_PATH_ENV) {
@@ -42,4 +45,17 @@ pub(crate) fn unique_suffix() -> u128 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_micros())
         .unwrap_or(0)
+}
+
+pub(crate) fn filter_environment(allowed: &[String]) -> Vec<(OsString, OsString)> {
+    let mut allowed_names: HashSet<String> = allowed.iter().cloned().collect();
+    allowed_names.extend(ESSENTIAL_ENV_VARS.iter().map(|name| (*name).to_string()));
+
+    env::vars_os()
+        .filter(|(key, _)| {
+            key.to_str()
+                .map(|name| allowed_names.contains(name))
+                .unwrap_or(false)
+        })
+        .collect()
 }


### PR DESCRIPTION
## Summary
- Extend the CLI isolation configuration to retain the compiled environment allowlist and feed it into sandbox executions. F:crates/cli/src/main.rs†L78-L83 F:crates/cli/src/main.rs†L171-L182 F:crates/cli/src/main.rs†L464-L475
- Return a structured compiled policy with a sorted environment allowlist and adjust policy compiler tests accordingly. F:crates/policy-compiler/src/lib.rs†L71-L95 F:crates/policy-compiler/src/lib.rs†L231-L335
- Propagate the environment allowlist through the sandbox runtime for both real and fake implementations. F:crates/sandbox-runtime/src/runtime.rs†L35-L48 F:crates/sandbox-runtime/src/real.rs†L51-L60 F:crates/sandbox-runtime/src/real.rs†L140-L146 F:crates/sandbox-runtime/src/fake.rs†L41-L48

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

## Avatar
- Senior Rust Developer — chosen to adjust cross-crate Rust APIs and keep runtime behavior coherent.

------
https://chatgpt.com/codex/tasks/task_e_68cd42a812308332a9376ae7b100e39c