### PR TITLE
Refactor policy rule storage into typed collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,6 +1153,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "qqrm-agent-lite"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aya",
+ "event-reporting",
+ "futures-core",
+ "futures-util",
+ "libc",
+ "log",
+ "prometheus",
+ "prost",
+ "qqrm-bpf-api",
+ "serde_json",
+ "serial_test",
+ "systemd-journal-logger",
+ "tempfile",
+ "tiny_http",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
 

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -86,8 +86,9 @@ mod tests {
         assert_eq!(policy.fs_default(), FsDefault::Strict);
         assert_eq!(policy.net_default(), NetDefault::Deny);
         assert_eq!(policy.exec_default(), ExecDefault::Allowlist);
-        let exec_allowed: Vec<_> = policy.exec_allowed().cloned().collect();
-        assert_eq!(exec_allowed, ["foo", "bar"]);
+        let mut exec_allowed: Vec<_> = policy.exec_allowed().cloned().collect();
+        exec_allowed.sort();
+        assert_eq!(exec_allowed, ["bar", "foo"]);
         assert!(policy.net_hosts().next().is_none());
         assert!(policy.fs_write_paths().next().is_none());
         assert!(policy.fs_read_paths().next().is_none());


### PR DESCRIPTION
## Summary
- replace `Policy`'s flat rule vector with typed collections and update serde conversion
- update CLI and compiler to use the new API and remove redundant deduplication
- expand policy-core tests to cover merge behavior and overrides

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cdf1b8614883329a00502f10c9f4b1