### PR TITLE
Document rule sets and drop unused permission enum

### DIFF
--- a/POLICY_SCHEMA.md
+++ b/POLICY_SCHEMA.md
@@ -71,11 +71,13 @@ System calls blocked via seccomp.
 
 ## Internal Representation
 
-`warden.toml` entries are converted into a list of permission rules during
-deserialization. Each rule is represented by the `policy-core` crate as a
-`Permission` enum variant (for example `FsRead`, `Exec`, `NetConnect`, or
-`EnvRead`). A parsed [`Policy`](./crates/policy-core/src/lib.rs) contains the
-requested `mode` and the collected permission rules in evaluation order.
+`warden.toml` entries are deserialized into dedicated rule sets that mirror the
+domains in the file. The `policy-core` crate stores filesystem, network,
+execution, syscall, and environment allowances in specialised structures that
+track defaults, detect duplicates, and preserve ordering for evaluation. The
+public [`Policy`](./crates/policy-core/src/policy.rs) exposes accessors such as
+`fs_default`, `exec_allowed`, and `net_hosts` to inspect the effective
+configuration alongside the selected `mode`.
 
 ## Workspace Policy
 `workspace.warden.toml` allows per-package overrides.

--- a/SPEC.md
+++ b/SPEC.md
@@ -136,15 +136,31 @@ pub struct Event {
 `qqrm-policy-core`
 
 ```rust
-pub enum Permission {
-  FsRead(PathSpec),
-  FsWrite(PathSpec),
-  Exec(ExecSpec),
-  NetConnect(HostPortSpec),
-  EnvRead(String),
+pub enum Mode {
+  Observe,
+  Enforce,
 }
 
-pub struct Policy { pub rules: Vec<Permission>, pub mode: Mode }
+pub struct Policy {
+  pub mode: Mode,
+  pub(crate) fs: FsRules,
+  pub(crate) net: NetRules,
+  pub(crate) exec: ExecRules,
+  pub(crate) syscall: SyscallRules,
+  pub(crate) env: EnvRules,
+}
+
+impl Policy {
+  pub fn fs_default(&self) -> FsDefault;
+  pub fn fs_read_paths(&self) -> impl Iterator<Item = &PathBuf>;
+  pub fn fs_write_paths(&self) -> impl Iterator<Item = &PathBuf>;
+  pub fn net_default(&self) -> NetDefault;
+  pub fn net_hosts(&self) -> impl Iterator<Item = &String>;
+  pub fn exec_default(&self) -> ExecDefault;
+  pub fn exec_allowed(&self) -> impl Iterator<Item = &String>;
+  pub fn syscall_deny(&self) -> impl Iterator<Item = &String>;
+  pub fn env_read_vars(&self) -> impl Iterator<Item = &String>;
+}
 ```
 
 `qqrm-policy-compiler`

--- a/crates/policy-core/src/lib.rs
+++ b/crates/policy-core/src/lib.rs
@@ -4,6 +4,6 @@ mod rules;
 mod validation;
 mod workspace;
 
-pub use crate::policy::{ExecDefault, FsDefault, Mode, NetDefault, Permission, Policy};
+pub use crate::policy::{ExecDefault, FsDefault, Mode, NetDefault, Policy};
 pub use crate::validation::{ValidationError, ValidationReport, ValidationWarning};
 pub use crate::workspace::{PolicyOverride, WorkspacePolicy};


### PR DESCRIPTION
## Summary
- remove the unused `Permission` enum from `policy-core` and expand policy tests to cover the rule-set accessors
- update POLICY_SCHEMA and SPEC to describe the rule-set based permission model

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68cfdb46dfb48332a57d6158b352c074