### PR TITLE
Restrict sandbox environment variables

### DIFF
--- a/crates/cli/src/policy.rs
+++ b/crates/cli/src/policy.rs
@@ -11,6 +11,7 @@ pub(crate) struct IsolationConfig {
     pub(crate) mode: Mode,
     pub(crate) syscall_deny: Vec<String>,
     pub(crate) maps_layout: MapsLayout,
+    pub(crate) allowed_env_vars: Vec<String>,
 }
 
 pub(crate) fn setup_isolation(
@@ -44,12 +45,16 @@ pub(crate) fn setup_isolation(
 
     let compiled = qqrm_policy_compiler::compile(&policy)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
-    let CompiledPolicy { maps_layout, .. } = compiled;
+    let CompiledPolicy {
+        maps_layout,
+        allowed_env_vars,
+    } = compiled;
 
     Ok(IsolationConfig {
         mode: policy.mode,
         syscall_deny: policy.syscall_deny().cloned().collect(),
         maps_layout,
+        allowed_env_vars,
     })
 }
 

--- a/crates/cli/src/sandbox.rs
+++ b/crates/cli/src/sandbox.rs
@@ -17,6 +17,7 @@ pub(crate) fn run_in_sandbox(
         mode,
         &isolation.syscall_deny,
         &isolation.maps_layout,
+        &isolation.allowed_env_vars,
     );
     let shutdown_result = sandbox.shutdown();
     let status = match run_result {

--- a/crates/sandbox-runtime/src/command_env.rs
+++ b/crates/sandbox-runtime/src/command_env.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::process::Command;
+
+/// Restrict the command environment to variables explicitly allowed by policy.
+pub(crate) fn restrict_command_environment(cmd: &mut Command, allowed: &[String]) {
+    let overrides: HashMap<OsString, Option<OsString>> = cmd
+        .get_envs()
+        .map(|(key, value)| (key.to_os_string(), value.map(|v| v.to_os_string())))
+        .collect();
+
+    cmd.env_clear();
+
+    for allowed_key in allowed {
+        let key_os = OsString::from(allowed_key);
+        match overrides.get(&key_os) {
+            Some(Some(value)) => {
+                cmd.env(&key_os, value);
+            }
+            Some(None) => {}
+            None => {
+                if let Some(value) = std::env::var_os(&key_os) {
+                    cmd.env(&key_os, value);
+                }
+            }
+        }
+    }
+}

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -1,3 +1,4 @@
+use crate::command_env::restrict_command_environment;
 use crate::layout::LayoutRecorder;
 use crate::util::{events_path, fake_cgroup_dir};
 use policy_core::Mode;
@@ -44,10 +45,12 @@ impl FakeSandbox {
         mode: Mode,
         _deny: &[String],
         layout: &MapsLayout,
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         if let Some(recorder) = &mut self.layout_recorder {
             recorder.record(layout, mode)?;
         }
+        restrict_command_environment(&mut command, allowed_env);
         command.status()
     }
 

--- a/crates/sandbox-runtime/src/lib.rs
+++ b/crates/sandbox-runtime/src/lib.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod bpf;
 mod cgroup;
+mod command_env;
 mod fake;
 mod layout;
 mod maps;

--- a/crates/sandbox-runtime/src/runtime.rs
+++ b/crates/sandbox-runtime/src/runtime.rs
@@ -40,10 +40,11 @@ impl Sandbox {
         mode: Mode,
         deny: &[String],
         layout: &MapsLayout,
+        allowed_env: &[String],
     ) -> io::Result<ExitStatus> {
         match &mut self.inner {
-            SandboxImpl::Real(real) => real.run(command, mode, deny, layout),
-            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout),
+            SandboxImpl::Real(real) => real.run(command, mode, deny, layout, allowed_env),
+            SandboxImpl::Fake(fake) => fake.run(command, mode, deny, layout, allowed_env),
         }
     }
 
@@ -53,5 +54,106 @@ impl Sandbox {
             SandboxImpl::Real(real) => real.shutdown(),
             SandboxImpl::Fake(fake) => fake.shutdown(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::io;
+    use std::process::Command;
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    struct VarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl VarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: guarded by `ENV_LOCK`, so environment mutations are serialized.
+            unsafe {
+                env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            // SAFETY: guarded by `ENV_LOCK`, so environment mutations are serialized.
+            unsafe {
+                env::remove_var(key);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for VarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                // SAFETY: guarded by `ENV_LOCK`, so environment mutations are serialized.
+                unsafe {
+                    env::set_var(self.key, value);
+                }
+            } else {
+                // SAFETY: guarded by `ENV_LOCK`, so environment mutations are serialized.
+                unsafe {
+                    env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    fn empty_layout() -> MapsLayout {
+        MapsLayout {
+            mode_flags: Vec::new(),
+            exec_allowlist: Vec::new(),
+            net_rules: Vec::new(),
+            net_parents: Vec::new(),
+            fs_rules: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn restricts_environment_to_allowed_keys() -> io::Result<()> {
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _fake = VarGuard::set(super::FAKE_SANDBOX_ENV, "1");
+        let _allowed_parent = VarGuard::set("ALLOWED_PARENT", "visible");
+        let _blocked_parent = VarGuard::set("BLOCKED_PARENT", "hidden");
+
+        let mut sandbox = Sandbox::new()?;
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("test \"${ALLOWED_PARENT}\" = visible && test -z \"${BLOCKED_PARENT}\"");
+
+        let allowed = vec!["ALLOWED_PARENT".to_string(), "PATH".to_string()];
+        let status = sandbox.run(command, Mode::Enforce, &[], &empty_layout(), &allowed)?;
+        assert!(status.success());
+        Ok(())
+    }
+
+    #[test]
+    fn filters_command_defined_environment() -> io::Result<()> {
+        let _guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let _fake = VarGuard::set(super::FAKE_SANDBOX_ENV, "1");
+        let _clear_allowed = VarGuard::remove("ALLOWED_OVERRIDE");
+
+        let mut sandbox = Sandbox::new()?;
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("test \"${ALLOWED_OVERRIDE}\" = custom && test -z \"${BLOCKED_OVERRIDE}\"");
+        command.env("ALLOWED_OVERRIDE", "custom");
+        command.env("BLOCKED_OVERRIDE", "value");
+
+        let allowed = vec!["ALLOWED_OVERRIDE".to_string(), "PATH".to_string()];
+        let status = sandbox.run(command, Mode::Enforce, &[], &empty_layout(), &allowed)?;
+        assert!(status.success());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- propagate the policy env allowlist through the CLI isolation configuration and sandbox runtime entry point
- filter child environments in both real and fake sandboxes so only allowed variables are present when commands execute
- add unit tests validating that disallowed variables disappear while allowed values (including command overrides) remain readable

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d0eeaaf33c83328a1426bc368ae426