### PR TITLE
Support workload unit mappings

### DIFF
--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -19,6 +19,8 @@ pub const EVENT_RINGBUF_CAPACITY_BYTES: u32 = 4096;
 pub const EVENT_COUNT_SLOTS: u32 = 1;
 /// Number of entries in the mode flags map.
 pub const MODE_FLAGS_CAPACITY: u32 = 1;
+/// Maximum number of workload-to-unit mappings supported by the eBPF map.
+pub const WORKLOAD_UNITS_CAPACITY: u32 = 256;
 /// Flag value stored in the mode map when running in observe mode.
 pub const MODE_FLAG_OBSERVE: u32 = 0;
 /// Flag value stored in the mode map when running in enforce mode.

--- a/crates/sandbox-runtime/src/fake.rs
+++ b/crates/sandbox-runtime/src/fake.rs
@@ -54,6 +54,10 @@ impl FakeSandbox {
         command.status()
     }
 
+    pub(crate) fn write_workload_units(&mut self, _entries: &[(u32, u32)]) -> io::Result<()> {
+        Ok(())
+    }
+
     pub(crate) fn shutdown(mut self) -> io::Result<()> {
         if let Some(agent) = self.agent.take() {
             agent.stop()?;

--- a/crates/sandbox-runtime/src/real.rs
+++ b/crates/sandbox-runtime/src/real.rs
@@ -2,7 +2,7 @@ use crate::agent::{AgentHandle, start_agent};
 use crate::bpf::{load_bpf, take_events_ring};
 use crate::cgroup::Cgroup;
 use crate::command_env::restrict_command_environment;
-use crate::maps::{populate_maps, write_mode_flag};
+use crate::maps::{populate_maps, write_mode_flag, write_workload_units};
 use crate::seccomp::apply_seccomp;
 use crate::util::events_path;
 use aya::programs::cgroup_sock_addr::CgroupSockAddrLink;
@@ -61,6 +61,10 @@ impl RealSandbox {
         self.install_pre_exec(&mut command, deny, layout.clone(), mode, allowed_env)?;
         let mut child = command.spawn()?;
         child.wait()
+    }
+
+    pub(crate) fn write_workload_units(&self, entries: &[(u32, u32)]) -> io::Result<()> {
+        self.with_bpf(|bpf| write_workload_units(bpf, entries))
     }
 
     pub(crate) fn shutdown(mut self) -> io::Result<()> {


### PR DESCRIPTION
## Summary
- add an explicit workload unit capacity constant and expose a `WORKLOAD_UNITS` map so eBPF programs derive their current unit from per-process mappings
- extend host utilities and the sandbox runtime with helpers to populate workload-to-unit associations before spawning workloads
- add tests validating that non-zero workload units flow into emitted events and that the sandbox API accepts workload unit configuration

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d0f540242083328544558d1d2b1187