### PR TITLE
Document implicit strict filesystem allowances

### DIFF
--- a/END_TO_END_TUTORIAL.md
+++ b/END_TO_END_TUTORIAL.md
@@ -27,11 +27,18 @@ allowed = ["rustc", "rustdoc", "rustfmt"]
 hosts = ["127.0.0.1:8080"]
 
 [allow.fs]
+# Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR).
 write_extra = ["/tmp/warden-scratch"]
+# Strict mode implicitly allows reading from the workspace root.
 read_extra = ["/usr/include"]
 ```
 
 Save changes.
+
+Strict filesystem mode always grants write access to Cargo's `target` directory (which
+covers `OUT_DIR`) and read access to the workspace root. The `write_extra` and
+`read_extra` arrays extend those implicit permissions when the build needs
+additional paths.
 
 ## 3. Build under enforcement
 

--- a/POLICY_SCHEMA.md
+++ b/POLICY_SCHEMA.md
@@ -15,7 +15,9 @@ allowed = ["rustc", "rustdoc"]
 hosts = ["127.0.0.1:1080"]
 
 [allow.fs]
+# Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR).
 write_extra = ["/tmp/warden-scratch"]
+# Strict mode implicitly allows reading from the workspace root.
 read_extra = ["/usr/include"]
 
 [allow.env]
@@ -58,10 +60,12 @@ List of executables permitted when `exec.default = "allowlist"`.
 List of hosts allowed when `net.default = "deny"`. Each entry uses `host:port` form.
 
 ### `allow.fs.write_extra`
-Additional paths allowed for writing when `fs.default = "strict"`.
+Additional write paths permitted beyond the implicit Cargo `target` directory when
+`fs.default = "strict"`.
 
 ### `allow.fs.read_extra`
-Additional paths allowed for reading when `fs.default = "strict"`.
+Additional read paths permitted beyond the workspace root when
+`fs.default = "strict"`.
 
 ### `allow.env.read`
 Environment variables that build scripts are allowed to read explicitly.

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,12 +202,18 @@ allowed = ["rustc", "rustdoc", "ar", "ld", "cc", "pkg-config"]
 hosts = ["127.0.0.1:1080"]  # example local proxy
 
 [allow.fs]
+# Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR).
 write_extra = ["/tmp/warden-scratch"]
+# Strict mode implicitly allows reading from the workspace root.
 read_extra  = ["/usr/include"]
 
 [allow.env]
 read = ["CARGO", "OUT_DIR"]
 ```
+
+Strict filesystem mode automatically whitelists the workspace root for reads and the
+Cargo `target` directory (which covers `OUT_DIR`) for writes. The `allow.fs`
+settings extend those implicit permissions for additional paths.
 
 Optional declarations in package `Cargo.toml`:
 

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -40,7 +40,9 @@ pub(crate) fn exec_with<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> 
          hosts = []\n\
          \n\
          [allow.fs]\n\
+         # Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR).\n\
          write_extra = []\n\
+         # Strict mode implicitly allows reading from the workspace root.\n\
          read_extra = []\n",
         allowed
     );
@@ -80,6 +82,12 @@ mod tests {
         assert!(config.contains("fs.default = \"strict\""));
         assert!(config.contains("net.default = \"deny\""));
         assert!(config.contains("exec.default = \"allowlist\""));
+        assert!(config.contains(
+            "# Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR)."
+        ));
+        assert!(
+            config.contains("# Strict mode implicitly allows reading from the workspace root.")
+        );
 
         let policy = Policy::from_toml_str(&config).unwrap();
         assert_eq!(policy.mode, Mode::Enforce);


### PR DESCRIPTION
## Summary
- document the implicit workspace read and target write paths in the `cargo warden init` template and regression tests
- update tutorial and reference documentation to describe the automatic allowances applied in strict filesystem mode

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d1e3d82d10833286ca0d17614bcada