### PR TITLE
Refactor agent-lite broadcast output handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aya",
+ "cfg-if",
  "event-reporting",
  "futures-core",
  "futures-util",

--- a/crates/agent-lite/Cargo.toml
+++ b/crates/agent-lite/Cargo.toml
@@ -21,6 +21,7 @@ systemd-journal-logger = "2.2"
 libc = "0.2"
 prometheus = "0.14.0"
 tiny_http = "0.12"
+cfg-if = "1.0"
 
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"], optional = true }
 tonic = { version = "0.10", features = ["transport"], optional = true }


### PR DESCRIPTION
## Summary
- add cfg-if to agent-lite and factor write_outputs into a single helper that accepts an optional broadcast sender
- invoke the helper via cfg_if! so grpc builds forward the channel while other builds pass None, reusing the same pattern in tests

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d283fa05708332b6f1e7af0c6ef1f0