### PR TITLE
Allow strict mode to auto-allow build directories

### DIFF
--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 pub(crate) struct DirGuard {
@@ -15,5 +16,52 @@ impl DirGuard {
 impl Drop for DirGuard {
     fn drop(&mut self) {
         let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+pub(crate) struct EnvVarGuard {
+    key: String,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub(crate) fn set(key: &str, value: OsString) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            // SAFETY: tests invoke these helpers in a single-threaded context.
+            std::env::set_var(key, &value);
+        }
+        Self {
+            key: key.to_owned(),
+            previous,
+        }
+    }
+
+    pub(crate) fn unset(key: &str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe {
+            // SAFETY: tests invoke these helpers in a single-threaded context.
+            std::env::remove_var(key);
+        }
+        Self {
+            key: key.to_owned(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = self.previous.take() {
+            unsafe {
+                // SAFETY: tests invoke these helpers in a single-threaded context.
+                std::env::set_var(&self.key, value);
+            }
+        } else {
+            unsafe {
+                // SAFETY: tests invoke these helpers in a single-threaded context.
+                std::env::remove_var(&self.key);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect workspace roots, target directories, and OUT_DIR hints when strict filesystem mode is active
- normalize filesystem paths more defensively and provide helpers for test environment variable management
- extend CLI unit and sandbox integration tests to cover auto-inserted strict-mode rules

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d3171b74ac833283a7b1ba69f70b7c