### PR TITLE
Add report format selection to CLI report command

### DIFF
--- a/END_TO_END_TUTORIAL.md
+++ b/END_TO_END_TUTORIAL.md
@@ -64,7 +64,25 @@ Tail the log to observe decisions in real time:
 tail -f warden.log
 ```
 
-## 5. Workspaces
+## 5. Export reports
+
+```bash
+cargo warden report
+```
+
+By default, the command prints recent sandbox events in a readable text format. Use JSON when integrating with tooling:
+
+```bash
+cargo warden report --format json
+```
+
+Generate a SARIF file for ingestion by security scanners:
+
+```bash
+cargo warden report --format sarif --output warden.sarif
+```
+
+## 6. Workspaces
 
 For multi-crate workspaces, create `workspace.warden.toml` to override rules per member:
 

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -1,13 +1,52 @@
-use std::io;
+use std::io::{self, Write};
 use std::path::Path;
 
+use event_reporting::EventRecord;
 use event_reporting::export_sarif;
 
 use crate::commands::read_recent_events;
 
-pub(crate) fn exec(output: &str) -> io::Result<()> {
-    let events = read_recent_events(Path::new("warden-events.jsonl"), usize::MAX)?;
-    export_sarif(&events, Path::new(output))
+const DEFAULT_SARIF_OUTPUT: &str = "warden.sarif";
+const EVENTS_LOG: &str = "warden-events.jsonl";
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ReportFormat {
+    Text,
+    Json,
+    Sarif,
+}
+
+pub(crate) fn exec(format: ReportFormat, output: Option<&str>) -> io::Result<()> {
+    let events = read_recent_events(Path::new(EVENTS_LOG), usize::MAX)?;
+    match format {
+        ReportFormat::Text => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            export_text(&events, &mut handle)
+        }
+        ReportFormat::Json => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            export_json(&events, &mut handle)
+        }
+        ReportFormat::Sarif => {
+            let path = Path::new(output.unwrap_or(DEFAULT_SARIF_OUTPUT));
+            export_sarif(&events, path)
+        }
+    }
+}
+
+fn export_text<W: Write>(events: &[EventRecord], writer: &mut W) -> io::Result<()> {
+    for event in events {
+        writeln!(writer, "{event}")?;
+    }
+    Ok(())
+}
+
+fn export_json<W: Write>(events: &[EventRecord], writer: &mut W) -> io::Result<()> {
+    serde_json::to_writer(&mut *writer, events).map_err(io::Error::other)?;
+    writeln!(writer)?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -42,7 +81,55 @@ mod tests {
         let _guard = crate::test_support::DirGuard::change_to(dir.path());
 
         File::create("warden-events.jsonl").unwrap();
-        exec("out.sarif").unwrap();
+        exec(ReportFormat::Sarif, Some("out.sarif")).unwrap();
         assert!(dir.path().join("out.sarif").exists());
+    }
+
+    #[test]
+    fn report_defaults_sarif_output_path() {
+        let dir = tempdir().unwrap();
+        let _guard = crate::test_support::DirGuard::change_to(dir.path());
+
+        File::create("warden-events.jsonl").unwrap();
+        exec(ReportFormat::Sarif, None).unwrap();
+        assert!(dir.path().join("warden.sarif").exists());
+    }
+
+    #[test]
+    fn text_exporter_formats_events() {
+        let events = vec![EventRecord {
+            pid: 1,
+            unit: 0,
+            action: 2,
+            verdict: 1,
+            container_id: 3,
+            caps: 4,
+            path_or_addr: "/bin/example".into(),
+        }];
+        let mut buffer = Vec::new();
+        export_text(&events, &mut buffer).unwrap();
+        assert_eq!(
+            String::from_utf8(buffer).unwrap(),
+            "pid=1 unit=0 action=2 verdict=1 container_id=3 caps=4 path_or_addr=/bin/example\n"
+        );
+    }
+
+    #[test]
+    fn json_exporter_serializes_events() {
+        let events = vec![EventRecord {
+            pid: 5,
+            unit: 1,
+            action: 9,
+            verdict: 0,
+            container_id: 8,
+            caps: 16,
+            path_or_addr: "127.0.0.1:80".into(),
+        }];
+        let mut buffer = Vec::new();
+        export_json(&events, &mut buffer).unwrap();
+        assert_eq!(
+            String::from_utf8(buffer).unwrap(),
+            "[{\"pid\":5,\"unit\":1,\"action\":9,\"verdict\":0,\"container_id\":8,\"caps\":16,\"path_or_addr\":\"127.0.0.1:80\"}]\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add a `--format` flag to `cargo warden report` with text as the default and optional SARIF output path
- implement stdout exporters for text and JSON while keeping SARIF generation for explicit requests
- extend parser and report tests plus the end-to-end tutorial to document the new formats

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d316eae5248332a9b48c0c378e6ab0