### PR TITLE
Remove cargo llvm-cov CI check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,9 +39,6 @@ jobs:
           tool: cargo-udeps
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
-      - uses: taiki-e/install-action@v2
-        with:
           tool: cargo-nextest
       - name: cargo fmt --all -- --check
         id: cargo_fmt
@@ -75,10 +72,6 @@ jobs:
           cargo deny check --disable-fetch
         shell: bash
         continue-on-error: true
-      - name: cargo llvm-cov --no-report
-        id: cargo_llvm_cov
-        run: cargo llvm-cov --no-report
-        continue-on-error: true
       - uses: dtolnay/rust-toolchain@nightly
       - name: cargo +nightly udeps --all-targets --all-features
         id: cargo_udeps
@@ -106,7 +99,6 @@ jobs:
           record_outcome "${{ steps.cargo_machete.outcome }}" "cargo machete"
           record_outcome "${{ steps.cargo_audit.outcome }}" "cargo audit"
           record_outcome "${{ steps.cargo_deny.outcome }}" "cargo deny check --disable-fetch"
-          record_outcome "${{ steps.cargo_llvm_cov.outcome }}" "cargo llvm-cov --no-report"
           record_outcome "${{ steps.cargo_udeps.outcome }}" "cargo +nightly udeps --all-targets --all-features"
 
           if [ -s "$failures_file" ]; then


### PR DESCRIPTION
## Summary
- remove the cargo-llvm-cov installation and job step from the CI workflow
- stop aggregating the removed cargo-llvm-cov outcome when summarizing failures

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d34666f8a083329c660a1e0c2f39af