### PR TITLE
Support metadata-driven and trust DB policy overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ dependencies = [
  "qqrm-policy-compiler",
  "qqrm-policy-core",
  "qqrm-sandbox-runtime",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
@@ -1441,6 +1442,12 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = "../sandbox-runtime" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+semver = "1"
 toml = "0.8"
 event-reporting = { version = "0.1.0", path = "../event-reporting" }
 


### PR DESCRIPTION
## Summary
- load cargo-warden package metadata and trust database entries before merging CLI-supplied policies
- interpret metadata and trust permissions to extend exec, filesystem, network, environment, and syscall rules
- add unit tests that exercise metadata overrides, trust database merges, and network helper decoding

## Testing
- `cargo fmt`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`


------
https://chatgpt.com/codex/tasks/task_e_68d34e032d2083329ef66c18c195b69b