### PR TITLE
Expose descriptive Prometheus unit labels

### DIFF
--- a/AVATAR.md
+++ b/AVATAR.md
@@ -1,0 +1,6 @@
+# Avatar Selection
+
+- **ID**: `senior_developer`
+- **Name**: Senior Rust Developer
+- **Source**: https://qqrm.github.io/avatars-mcp/senior_developer.png
+- **Rationale**: Aligns with the senior Rust engineering responsibilities for this task.


### PR DESCRIPTION
## Summary
- map per-unit Prometheus metrics to human-readable workload names while keeping a fallback for unknown identifiers
- clear cached unit labels during test resets and extend the metrics endpoint test to cover named and numeric labels
- record the chosen MCP avatar for this workspace

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d38e6840448332882389a0842232f1