### PR TITLE
Extend event payload with process metadata and suggestions

### DIFF
--- a/EVENT_LOG_ABI.md
+++ b/EVENT_LOG_ABI.md
@@ -7,6 +7,8 @@ The eBPF layer emits `Event` records via a ring buffer. This ABI defines the lay
 #[derive(Clone, Copy, Debug)]
 pub struct Event {
     pub pid: u32,
+    pub tgid: u32,
+    pub time_ns: u64,
     pub unit: u8,        // 0 Other, 1 BuildRs, 2 ProcMacro, 3 Rustc, 4 Linker
     pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
     pub verdict: u8,     // 0 Allowed, 1 Denied
@@ -14,16 +16,20 @@ pub struct Event {
     pub container_id: u64,
     pub caps: u64,       // Linux capability bitmask
     pub path_or_addr: [u8; 256], // null-terminated path or network address
+    pub needed_perm: [u8; 64],   // suggested policy key (utf-8, null-terminated)
 }
 ```
 
 - **pid** – process identifier.
+- **tgid** – thread group identifier for the process.
+- **time_ns** – monotonic timestamp at which the event was captured.
 - **unit** – workload category generating the event.
 - **action** – operation being audited.
 - **path_or_addr** – associated filesystem path or network address.
 - **verdict** – allow (`0`) or deny (`1`).
 - **container_id** – identifier of the container or sandbox.
 - **caps** – Linux capability bitmask held by the process.
+- **needed_perm** – suggested policy entry required to grant the attempted operation.
 - Rename operations emit separate events for the source and destination paths when write access is denied, ensuring fake
   sandbox consumers and layout recorders observe both sides of the attempted move.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -128,6 +128,9 @@ pub struct Event {
   pub unit: u8,        // 0 Other, 1 BuildRs, 2 ProcMacro, 3 Rustc, 4 Linker
   pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
   pub verdict: u8,     // 0 Allowed, 1 Denied
+  pub reserved: u8,
+  pub container_id: u64,
+  pub caps: u64,
   pub path_or_addr: [u8; 256],
   pub needed_perm: [u8; 64],
 }

--- a/crates/agent-lite/proto/agent.proto
+++ b/crates/agent-lite/proto/agent.proto
@@ -12,6 +12,9 @@ message EventRecord {
   uint64 container_id = 5;
   uint64 caps = 6;
   string path_or_addr = 7;
+  uint32 tgid = 8;
+  uint64 time_ns = 9;
+  string needed_perm = 10;
 }
 
 service Agent {

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -84,15 +84,19 @@ pub struct FsRuleEntry {
 #[derive(Clone, Copy, Debug)]
 /// Event emitted by BPF programs.
 pub struct Event {
-    /// Process identifier.
+    /// Thread identifier (kernel PID).
     pub pid: u32,
+    /// Process identifier (thread group ID).
+    pub tgid: u32,
+    /// Monotonic timestamp captured at emission time (nanoseconds).
+    pub time_ns: u64,
     /// Workload category that produced the event.
     pub unit: u8,
     /// Operation being monitored.
     pub action: u8,
     /// Allow (0) or deny (1).
     pub verdict: u8,
-    /// Reserved for future use.
+    /// Reserved for future use and alignment.
     pub reserved: u8,
     /// Identifier of the container or sandbox.
     pub container_id: u64,
@@ -100,6 +104,8 @@ pub struct Event {
     pub caps: u64,
     /// Null-terminated path or network address.
     pub path_or_addr: [u8; 256],
+    /// Suggested policy entry required to permit the operation.
+    pub needed_perm: [u8; 64],
 }
 
 #[cfg(test)]
@@ -139,6 +145,6 @@ mod tests {
 
     #[test]
     fn event_size() {
-        assert_eq!(size_of::<Event>(), 280);
+        assert_eq!(size_of::<Event>(), 360);
     }
 }

--- a/crates/cli/src/commands/events.rs
+++ b/crates/cli/src/commands/events.rs
@@ -38,12 +38,15 @@ mod tests {
             "{}",
             serde_json::json!({
                 "pid": 1,
+                "tgid": 10,
+                "time_ns": 1000,
                 "unit": 0,
                 "action": 3,
                 "verdict": 0,
                 "container_id": 0,
                 "caps": 0,
-                "path_or_addr": "/bin/echo"
+                "path_or_addr": "/bin/echo",
+                "needed_perm": ""
             })
         )
         .unwrap();
@@ -52,12 +55,15 @@ mod tests {
             "{}",
             serde_json::json!({
                 "pid": 2,
+                "tgid": 20,
+                "time_ns": 2000,
                 "unit": 0,
                 "action": 4,
                 "verdict": 1,
                 "container_id": 0,
                 "caps": 0,
-                "path_or_addr": "1.2.3.4:80"
+                "path_or_addr": "1.2.3.4:80",
+                "needed_perm": "allow.net.hosts"
             })
         )
         .unwrap();

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -126,12 +126,15 @@ mod tests {
     fn exports_sarif_file() {
         let record = event_reporting::EventRecord {
             pid: 2,
+            tgid: 4,
+            time_ns: 500,
             unit: 0,
             action: 3,
             verdict: 1,
             container_id: 0,
             caps: 0,
             path_or_addr: "/bin/bad".into(),
+            needed_perm: "allow.exec.allowed".into(),
         };
         let tmp = NamedTempFile::new().unwrap();
         export_sarif(std::slice::from_ref(&record), tmp.path()).unwrap();
@@ -166,30 +169,39 @@ mod tests {
         let events = vec![
             EventRecord {
                 pid: 1,
+                tgid: 10,
+                time_ns: 100,
                 unit: 0,
                 action: 2,
                 verdict: 0,
                 container_id: 3,
                 caps: 4,
                 path_or_addr: "/bin/allow".into(),
+                needed_perm: String::new(),
             },
             EventRecord {
                 pid: 2,
+                tgid: 20,
+                time_ns: 200,
                 unit: 0,
                 action: 5,
                 verdict: 1,
                 container_id: 7,
                 caps: 8,
                 path_or_addr: "/bin/deny".into(),
+                needed_perm: "allow.exec.allowed".into(),
             },
             EventRecord {
                 pid: 3,
+                tgid: 30,
+                time_ns: 300,
                 unit: 1,
                 action: 9,
                 verdict: 1,
                 container_id: 11,
                 caps: 12,
                 path_or_addr: "10.0.0.1:80".into(),
+                needed_perm: "allow.net.hosts".into(),
             },
         ];
         let stats = ReportStatistics::from_events(&events);
@@ -203,9 +215,9 @@ mod tests {
                 + "  unit 0: allowed=1, denied=1\n"
                 + "  unit 1: allowed=0, denied=1\n"
                 + "\n"
-                + "pid=1 unit=0 action=2 verdict=0 container_id=3 caps=4 path_or_addr=/bin/allow\n"
-                + "pid=2 unit=0 action=5 verdict=1 container_id=7 caps=8 path_or_addr=/bin/deny\n"
-                + "pid=3 unit=1 action=9 verdict=1 container_id=11 caps=12 path_or_addr=10.0.0.1:80\n",
+                + "pid=1 tgid=10 unit=0 action=2 verdict=0 time_ns=100 container_id=3 caps=4 needed_perm= path_or_addr=/bin/allow\n"
+                + "pid=2 tgid=20 unit=0 action=5 verdict=1 time_ns=200 container_id=7 caps=8 needed_perm=allow.exec.allowed path_or_addr=/bin/deny\n"
+                + "pid=3 tgid=30 unit=1 action=9 verdict=1 time_ns=300 container_id=11 caps=12 needed_perm=allow.net.hosts path_or_addr=10.0.0.1:80\n",
         );
     }
 
@@ -214,21 +226,27 @@ mod tests {
         let events = vec![
             EventRecord {
                 pid: 5,
+                tgid: 50,
+                time_ns: 500,
                 unit: 2,
                 action: 9,
                 verdict: 0,
                 container_id: 8,
                 caps: 16,
                 path_or_addr: "127.0.0.1:80".into(),
+                needed_perm: String::new(),
             },
             EventRecord {
                 pid: 6,
+                tgid: 60,
+                time_ns: 600,
                 unit: 2,
                 action: 10,
                 verdict: 1,
                 container_id: 9,
                 caps: 32,
                 path_or_addr: "192.168.0.1:53".into(),
+                needed_perm: "allow.net.hosts".into(),
             },
         ];
         let stats = ReportStatistics::from_events(&events);
@@ -249,6 +267,8 @@ mod tests {
 
         assert_eq!(json["events"].as_array().unwrap().len(), 2);
         assert_eq!(json["events"][0]["pid"], 5);
+        assert_eq!(json["events"][0]["tgid"], 50);
         assert_eq!(json["events"][1]["pid"], 6);
+        assert_eq!(json["events"][1]["needed_perm"], "allow.net.hosts");
     }
 }

--- a/crates/cli/tests/sandbox.rs
+++ b/crates/cli/tests/sandbox.rs
@@ -77,6 +77,8 @@ fn init_cargo_package(dir: &Path) -> io::Result<()> {
 
 const DENIED_ENDPOINT: &str = "198.51.100.10:443";
 const DENIED_PID: u32 = 7777;
+const DENIED_TGID: u32 = 8888;
+const DENIED_TIME_NS: u64 = 1_234_567_890;
 const DENIED_ACTION: u8 = 4;
 const DENIED_UNIT: u8 = UNIT_RUSTC as u8;
 const RENAME_PATH: &str = "/var/warden/forbidden";
@@ -114,12 +116,15 @@ fn write_violation_script(
     let script_path = dir.join(format!("deny-action-{action}.sh"));
     let deny_event = json!({
         "pid": DENIED_PID,
+        "tgid": DENIED_TGID,
+        "time_ns": DENIED_TIME_NS,
         "unit": unit,
         "action": action,
         "verdict": 1,
         "container_id": 0,
         "caps": 0,
         "path_or_addr": path_or_addr,
+        "needed_perm": "allow.net.hosts",
     })
     .to_string();
     fs::write(

--- a/crates/event-reporting/src/lib.rs
+++ b/crates/event-reporting/src/lib.rs
@@ -8,25 +8,31 @@ use std::path::Path;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventRecord {
     pub pid: u32,
+    pub tgid: u32,
+    pub time_ns: u64,
     pub unit: u8,
     pub action: u8,
     pub verdict: u8,
     pub container_id: u64,
     pub caps: u64,
     pub path_or_addr: String,
+    pub needed_perm: String,
 }
 
 impl fmt::Display for EventRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "pid={} unit={} action={} verdict={} container_id={} caps={} path_or_addr={}",
+            "pid={} tgid={} unit={} action={} verdict={} time_ns={} container_id={} caps={} needed_perm={} path_or_addr={}",
             self.pid,
+            self.tgid,
             self.unit,
             self.action,
             self.verdict,
+            self.time_ns,
             self.container_id,
             self.caps,
+            self.needed_perm,
             self.path_or_addr
         )
     }
@@ -76,12 +82,15 @@ mod tests {
     fn sarif_contains_events() {
         let records = vec![EventRecord {
             pid: 42,
+            tgid: 24,
+            time_ns: 123,
             unit: 1,
             action: 3,
             verdict: 1,
             container_id: 99,
             caps: 0,
             path_or_addr: "/bin/deny".into(),
+            needed_perm: "allow.fs.read_extra".into(),
         }];
         let sarif = sarif_from_events(&records);
         assert_eq!(sarif["version"], "2.1.0");
@@ -92,12 +101,15 @@ mod tests {
     fn export_writes_file() {
         let record = EventRecord {
             pid: 7,
+            tgid: 70,
+            time_ns: 456,
             unit: 1,
             action: 3,
             verdict: 1,
             container_id: 5,
             caps: 0,
             path_or_addr: "/bin/bad".into(),
+            needed_perm: "allow.exec.allowed".into(),
         };
         let tmp = NamedTempFile::new().unwrap();
         export_sarif(std::slice::from_ref(&record), tmp.path()).unwrap();


### PR DESCRIPTION
## Summary
- align the Event ABI with the spec by adding `tgid`, `time_ns`, and `needed_perm` while updating the BPF core to populate them
- surface the extended event metadata through agent-lite, CLI reporting, and gRPC serialization layers
- refresh documentation and expand tests to cover the richer event payload

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d3acc840608332a0f91dd3fa115280