### PR TITLE
Load trust permissions from config database

### DIFF
--- a/crates/testkits/src/lib.rs
+++ b/crates/testkits/src/lib.rs
@@ -181,12 +181,15 @@ impl TestProject {
         let script_path = self.child(format!("{stem}.sh"));
         let deny_event = serde_json::json!({
             "pid": 7777u32,
+            "tgid": 8888u32,
+            "time_ns": 1_234_567_890u64,
             "unit": unit,
             "action": action,
             "verdict": 1,
             "container_id": 0,
             "caps": 0,
             "path_or_addr": path_or_addr,
+            "needed_perm": "allow.net.hosts",
         })
         .to_string();
 


### PR DESCRIPTION
## Summary
- load trust database entries from the XDG config directory (or an explicit override) and merge them into the CLI policy
- add coverage for a missing trust database while keeping the existing trust-permission merge test green
- make the fake sandbox helper emit complete event records so the CLI integration tests can rely on it

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d3b43a07148332b709870bb77db6d5