### PR TITLE
Add needed permission hints to diagnostics

### DIFF
--- a/crates/agent-lite/src/lib.rs
+++ b/crates/agent-lite/src/lib.rs
@@ -296,9 +296,14 @@ fn diagnostic(record: &EventRecord) -> Option<String> {
     if record.verdict != VERDICT_DENIED {
         return None;
     }
+    let hint = if record.needed_perm.is_empty() {
+        String::new()
+    } else {
+        format!(" (hint: {})", record.needed_perm)
+    };
     match record.action {
-        ACTION_EXEC => Some(format!("Execution denied: {}", record.path_or_addr)),
-        ACTION_CONNECT => Some(format!("Network denied: {}", record.path_or_addr)),
+        ACTION_EXEC => Some(format!("Execution denied: {}{}", record.path_or_addr, hint)),
+        ACTION_CONNECT => Some(format!("Network denied: {}{}", record.path_or_addr, hint)),
         _ => None,
     }
 }
@@ -580,6 +585,7 @@ mod tests {
         let text = format!("{}", record);
         assert!(text.contains("pid=42"));
         assert!(text.contains("tgid=24"));
+        assert!(text.contains("hint=allow.fs.read_extra"));
         let json = serde_json::to_string(&record).unwrap();
         assert!(json.contains("\"pid\":42"));
         assert!(json.contains("\"tgid\":24"));
@@ -601,7 +607,7 @@ mod tests {
         };
         assert_eq!(
             diagnostic(&exec),
-            Some("Execution denied: /bin/bash".to_string())
+            Some("Execution denied: /bin/bash (hint: allow.exec.allowed)".to_string())
         );
         let net = EventRecord {
             pid: 1,
@@ -617,7 +623,7 @@ mod tests {
         };
         assert_eq!(
             diagnostic(&net),
-            Some("Network denied: 1.2.3.4:80".to_string())
+            Some("Network denied: 1.2.3.4:80 (hint: allow.net.hosts)".to_string())
         );
         let allow = EventRecord {
             pid: 1,

--- a/crates/cli/src/commands/report.rs
+++ b/crates/cli/src/commands/report.rs
@@ -217,8 +217,8 @@ mod tests {
                 + "  unit 1: allowed=0, denied=1\n"
                 + "\n"
                 + "pid=1 tgid=10 unit=0 action=2 verdict=0 time_ns=100 container_id=3 caps=4 needed_perm= path_or_addr=/bin/allow\n"
-                + "pid=2 tgid=20 unit=0 action=5 verdict=1 time_ns=200 container_id=7 caps=8 needed_perm=allow.exec.allowed path_or_addr=/bin/deny\n"
-                + "pid=3 tgid=30 unit=1 action=9 verdict=1 time_ns=300 container_id=11 caps=12 needed_perm=allow.net.hosts path_or_addr=10.0.0.1:80\n",
+                + "pid=2 tgid=20 unit=0 action=5 verdict=1 time_ns=200 container_id=7 caps=8 needed_perm=allow.exec.allowed path_or_addr=/bin/deny hint=allow.exec.allowed\n"
+                + "pid=3 tgid=30 unit=1 action=9 verdict=1 time_ns=300 container_id=11 caps=12 needed_perm=allow.net.hosts path_or_addr=10.0.0.1:80 hint=allow.net.hosts\n",
         );
     }
 

--- a/crates/event-reporting/src/lib.rs
+++ b/crates/event-reporting/src/lib.rs
@@ -21,20 +21,38 @@ pub struct EventRecord {
 
 impl fmt::Display for EventRecord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "pid={} tgid={} unit={} action={} verdict={} time_ns={} container_id={} caps={} needed_perm={} path_or_addr={}",
-            self.pid,
-            self.tgid,
-            self.unit,
-            self.action,
-            self.verdict,
-            self.time_ns,
-            self.container_id,
-            self.caps,
-            self.needed_perm,
-            self.path_or_addr
-        )
+        if self.needed_perm.is_empty() {
+            write!(
+                f,
+                "pid={} tgid={} unit={} action={} verdict={} time_ns={} container_id={} caps={} needed_perm={} path_or_addr={}",
+                self.pid,
+                self.tgid,
+                self.unit,
+                self.action,
+                self.verdict,
+                self.time_ns,
+                self.container_id,
+                self.caps,
+                self.needed_perm,
+                self.path_or_addr
+            )
+        } else {
+            write!(
+                f,
+                "pid={} tgid={} unit={} action={} verdict={} time_ns={} container_id={} caps={} needed_perm={} path_or_addr={} hint={}",
+                self.pid,
+                self.tgid,
+                self.unit,
+                self.action,
+                self.verdict,
+                self.time_ns,
+                self.container_id,
+                self.caps,
+                self.needed_perm,
+                self.path_or_addr,
+                self.needed_perm
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- include needed permission hints in agent diagnostics for denied events
- append hint strings to event display formatting
- update CLI text reporting tests to cover the new hint output

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d4497721b4833291562519a490088f