### PR TITLE
Enforce path dependency version checks

### DIFF
--- a/REPO_AGENTS.md
+++ b/REPO_AGENTS.md
@@ -4,4 +4,5 @@
 - Use avatars from the MCP server at `https://qqrm.github.io/avatars-mcp/` for all work.
 - Before starting work, review `SPEC.md` to choose the next task.
 - `repo-setup.sh` installs `actionlint` automatically for GitHub workflow linting.
+- Always run `./scripts/check_path_versions.sh` with the rest of the validation suite and resolve any missing versions on path dependencies before finishing a task.
 

--- a/crates/testkits/Cargo.toml
+++ b/crates/testkits/Cargo.toml
@@ -11,9 +11,9 @@ readme = "../../README.md"
 
 [dependencies]
 assert_cmd = "2"
-event-reporting = { path = "../event-reporting" }
-policy-core = { package = "qqrm-policy-core", path = "../policy-core" }
-sandbox-runtime = { package = "qqrm-sandbox-runtime", path = "../sandbox-runtime" }
+event-reporting = { version = "0.1.0", path = "../event-reporting" }
+policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
+sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = "../sandbox-runtime" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"


### PR DESCRIPTION
## Summary
- document the requirement to run the path dependency version check script in the repository instructions
- add explicit versions to the qqrm-testkits path dependencies so the script succeeds

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4ba5e82688332b87f386098b2ed1f