### PR TITLE
Add filesystem misuse example workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "qqrm-fs-outside-workspace"
+version = "0.1.0"
+
+[[package]]
 name = "qqrm-network-build"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/testkits",
     "examples/network-build",
     "examples/spawn-bash",
+    "examples/fs-outside-workspace",
     "crates/event-reporting",
 ]
 resolver = "2"

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,7 +12,7 @@ Status: Draft for public OSS release
 | CLI workflow (`build`, `run`, `init`, `status`, `report`) | ✅ Complete | `crates/cli` wires policy loading, sandbox orchestration, and reporting, supporting text, JSON, and SARIF outputs. |
 | Agent, metrics, and event export | ✅ Complete | `crates/agent-lite` and `crates/event-reporting` process ring-buffer events, publish Prometheus metrics, and generate SARIF logs. |
 | Test harness and fake sandbox | ✅ Complete | `crates/testkits` and the fake sandbox runtime back CLI integration tests and layout assertions. |
-| Example workspaces | 🟡 In Progress | `examples/network-build` and `examples/spawn-bash` exist; scenarios for filesystem misuse, proc-macro load, and git clone remain to be added. |
+| Example workspaces | 🟡 In Progress | `examples/network-build`, `examples/spawn-bash`, and `examples/fs-outside-workspace` exist; scenarios for proc-macro load and git clone remain to be added. |
 | Documentation set | 🟡 In Progress | README and security model drafts exist; `CONTRIBUTING`, `SECURITY`, `CODEOWNERS`, and PR templates are still outstanding. |
 
 Author: Alex + contributors
@@ -119,7 +119,7 @@ Workspace crates:
 * ✅ `crates/agent-lite` (spec: `qqrm-agent-lite`)
 * ✅ `crates/cli`
 * ✅ `crates/testkits` (spec: `qqrm-testkits`)
-* 🟡 `examples/*` – currently `network-build` and `spawn-bash`; additional cases (`ex_fs_outside_workspace`, `ex_proc_macro_hog`, `ex_git_clone_https`) remain TODO
+* 🟡 `examples/*` – currently `network-build`, `spawn-bash`, and `fs-outside-workspace`; additional cases (`ex_proc_macro_hog`, `ex_git_clone_https`) remain TODO
 
 Feature flags:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Run both examples under `cargo warden` using the helper script:
+Run the examples under `cargo warden` using the helper script:
 
 ```bash
 ./run_examples.sh
@@ -14,8 +14,10 @@ warning: network blocked: Operation not permitted (os error 1)
 
 == spawn-bash ==
 spawn blocked: Permission denied (os error 1)
+
+== fs-outside-workspace ==
+warning: write outside workspace blocked as expected: Operation not permitted (os error 1)
 ```
 
 An example Prometheus dashboard is provided in `PROMETHEUS_DASHBOARD.json`.
 The agent exposes metrics on a configurable port, allowing the dashboard to work out of the box.
-

--- a/examples/fs-outside-workspace/Cargo.toml
+++ b/examples/fs-outside-workspace/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qqrm-fs-outside-workspace"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]

--- a/examples/fs-outside-workspace/README.md
+++ b/examples/fs-outside-workspace/README.md
@@ -1,0 +1,4 @@
+# fs-outside-workspace
+
+This example crate has a `build.rs` script that attempts to write to `/tmp/cargo-warden-outside-workspace`.
+When the sandbox runs in enforce mode, the write should be denied and reported as a warning by the build script.

--- a/examples/fs-outside-workspace/build.rs
+++ b/examples/fs-outside-workspace/build.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let target = Path::new("/tmp/cargo-warden-outside-workspace");
+
+    match std::fs::write(target, b"blocked?") {
+        Ok(_) => {
+            println!(
+                "cargo:warning=unexpectedly wrote to {} — clean up manually if sandboxing was disabled",
+                target.display()
+            );
+            if let Err(err) = std::fs::remove_file(target) {
+                println!("cargo:warning=failed to remove {}: {err}", target.display());
+            }
+        }
+        Err(err) => {
+            println!("cargo:warning=write outside workspace blocked as expected: {err}");
+        }
+    }
+}

--- a/examples/fs-outside-workspace/src/lib.rs
+++ b/examples/fs-outside-workspace/src/lib.rs
@@ -1,0 +1,6 @@
+//! Dummy crate for demonstrating workspace write restrictions.
+
+/// Returns a static string so the crate has at least one item.
+pub fn marker() -> &'static str {
+    "fs-outside-workspace"
+}

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -14,3 +14,10 @@ printf '\n== spawn-bash ==\n'
     cd examples/spawn-bash
     cargo build
 )
+
+# Build fs-outside-workspace example
+printf '\n== fs-outside-workspace ==\n'
+(
+    cd examples/fs-outside-workspace
+    cargo build
+)


### PR DESCRIPTION
## Summary
- add the `fs-outside-workspace` example crate that demonstrates blocking writes outside the workspace
- wire the new example into the workspace members, helper script, and examples documentation
- refresh the spec status to reflect the additional filesystem misuse scenario

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68d4ba7e11c08332af8e4bbe687ddbdc