### PR TITLE
Add local CI parity script and documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "qqrm-fs-outside-workspace"
+version = "0.1.0"
+
+[[package]]
 name = "qqrm-network-build"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/testkits",
     "examples/network-build",
     "examples/spawn-bash",
+    "examples/fs-outside-workspace",
     "crates/event-reporting",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -40,3 +40,25 @@ The script installs the nightly toolchain, required components and the `bpf-link
 
 Generated artifacts are excluded from version control; rerun the script to refresh them.
 
+
+## Local CI parity
+
+Use `scripts/run_ci_checks.sh` to reproduce the pull request GitHub Actions checks locally. The script:
+
+- installs missing Debian packages (`pkg-config`, `libseccomp-dev`, `protobuf-compiler`, `jq`, `xxhash`),
+- installs the cargo subcommands required by the pipeline (`cargo-machete`, `cargo-audit`, `cargo-deny`, `cargo-nextest`, `cargo-udeps`, `cargo-fuzz`),
+- ensures the stable toolchain has the `rustfmt`, `clippy`, and `llvm-tools-preview` components, plus a nightly toolchain for `cargo udeps` and `cargo fuzz`,
+- runs the same validation commands as the CI jobs, including formatting, linting, tests, supply-chain checks, example runs, and fuzz builds.
+
+Run it from the repository root:
+
+```bash
+scripts/run_ci_checks.sh
+```
+
+For a byte-for-byte reproduction of the GitHub Actions workflow, run it through [wrkflw](https://github.com/bahdotsh/wrkflw):
+
+```bash
+wrkflw validate
+wrkflw run .github/workflows/CI.yml
+```

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,7 +12,7 @@ Status: Draft for public OSS release
 | CLI workflow (`build`, `run`, `init`, `status`, `report`) | ✅ Complete | `crates/cli` wires policy loading, sandbox orchestration, and reporting, supporting text, JSON, and SARIF outputs. |
 | Agent, metrics, and event export | ✅ Complete | `crates/agent-lite` and `crates/event-reporting` process ring-buffer events, publish Prometheus metrics, and generate SARIF logs. |
 | Test harness and fake sandbox | ✅ Complete | `crates/testkits` and the fake sandbox runtime back CLI integration tests and layout assertions. |
-| Example workspaces | 🟡 In Progress | `examples/network-build` and `examples/spawn-bash` exist; scenarios for filesystem misuse, proc-macro load, and git clone remain to be added. |
+| Example workspaces | 🟡 In Progress | `examples/network-build`, `examples/spawn-bash`, and `examples/fs-outside-workspace` exist; scenarios for proc-macro load and git clone remain to be added. |
 | Documentation set | 🟡 In Progress | README and security model drafts exist; `CONTRIBUTING`, `SECURITY`, `CODEOWNERS`, and PR templates are still outstanding. |
 
 Author: Alex + contributors
@@ -119,7 +119,7 @@ Workspace crates:
 * ✅ `crates/agent-lite` (spec: `qqrm-agent-lite`)
 * ✅ `crates/cli`
 * ✅ `crates/testkits` (spec: `qqrm-testkits`)
-* 🟡 `examples/*` – currently `network-build` and `spawn-bash`; additional cases (`ex_fs_outside_workspace`, `ex_proc_macro_hog`, `ex_git_clone_https`) remain TODO
+* 🟡 `examples/*` – currently `network-build`, `spawn-bash`, and `fs-outside-workspace`; additional cases (`ex_proc_macro_hog`, `ex_git_clone_https`) remain TODO
 
 Feature flags:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Run both examples under `cargo warden` using the helper script:
+Run the examples under `cargo warden` using the helper script:
 
 ```bash
 ./run_examples.sh
@@ -14,8 +14,10 @@ warning: network blocked: Operation not permitted (os error 1)
 
 == spawn-bash ==
 spawn blocked: Permission denied (os error 1)
+
+== fs-outside-workspace ==
+warning: write outside workspace blocked as expected: Operation not permitted (os error 1)
 ```
 
 An example Prometheus dashboard is provided in `PROMETHEUS_DASHBOARD.json`.
 The agent exposes metrics on a configurable port, allowing the dashboard to work out of the box.
-

--- a/examples/fs-outside-workspace/Cargo.toml
+++ b/examples/fs-outside-workspace/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qqrm-fs-outside-workspace"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]

--- a/examples/fs-outside-workspace/README.md
+++ b/examples/fs-outside-workspace/README.md
@@ -1,0 +1,4 @@
+# fs-outside-workspace
+
+This example crate has a `build.rs` script that attempts to write to `/tmp/cargo-warden-outside-workspace`.
+When the sandbox runs in enforce mode, the write should be denied and reported as a warning by the build script.

--- a/examples/fs-outside-workspace/build.rs
+++ b/examples/fs-outside-workspace/build.rs
@@ -1,0 +1,21 @@
+use std::path::Path;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let target = Path::new("/tmp/cargo-warden-outside-workspace");
+
+    match std::fs::write(target, b"blocked?") {
+        Ok(_) => {
+            println!(
+                "cargo:warning=unexpectedly wrote to {} — clean up manually if sandboxing was disabled",
+                target.display()
+            );
+            if let Err(err) = std::fs::remove_file(target) {
+                println!("cargo:warning=failed to remove {}: {err}", target.display());
+            }
+        }
+        Err(err) => {
+            println!("cargo:warning=write outside workspace blocked as expected: {err}");
+        }
+    }
+}

--- a/examples/fs-outside-workspace/src/lib.rs
+++ b/examples/fs-outside-workspace/src/lib.rs
@@ -1,0 +1,6 @@
+//! Dummy crate for demonstrating workspace write restrictions.
+
+/// Returns a static string so the crate has at least one item.
+pub fn marker() -> &'static str {
+    "fs-outside-workspace"
+}

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -14,3 +14,10 @@ printf '\n== spawn-bash ==\n'
     cd examples/spawn-bash
     cargo build
 )
+
+# Build fs-outside-workspace example
+printf '\n== fs-outside-workspace ==\n'
+(
+    cd examples/fs-outside-workspace
+    cargo build
+)

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/run_ci_checks.sh [--skip-install]
+
+Run the same validation commands as the CI workflow. By default the script
+installs any missing system packages and cargo subcommands before executing the
+checks. Pass --skip-install to require all dependencies to be present already.
+USAGE
+}
+
+log_step() {
+  printf '\n[%s] %s\n' "$(date -u '+%H:%M:%S')" "$1"
+}
+
+ensure_apt_packages() {
+  local install=${1}
+  shift
+
+  if ! command -v apt-get >/dev/null 2>&1; then
+    echo "error: apt-get is required to install system dependencies" >&2
+    exit 1
+  fi
+
+  local missing=()
+  for pkg in "$@"; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+      missing+=("$pkg")
+    fi
+  done
+
+  if ((${#missing[@]} == 0)); then
+    return
+  fi
+
+  if ! ${install}; then
+    echo "error: missing packages: ${missing[*]}" >&2
+    echo "hint: rerun without --skip-install or install them manually" >&2
+    exit 1
+  fi
+
+  if ((EUID != 0)); then
+    echo "error: missing packages: ${missing[*]}" >&2
+    echo "hint: rerun as root or install manually using apt-get" >&2
+    exit 1
+  fi
+
+  apt-get update
+  apt-get install -y "${missing[@]}"
+}
+
+ensure_cargo_tool() {
+  local install=${1}
+  local binary="$2"
+  local crate="$3"
+
+  if command -v "$binary" >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! ${install}; then
+    echo "error: missing cargo binary '$binary'" >&2
+    echo "hint: rerun without --skip-install or install it manually via 'cargo install ${crate} --locked'" >&2
+    exit 1
+  fi
+
+  cargo install "$crate" --locked
+}
+
+ensure_nightly() {
+  local install=${1}
+  if rustup toolchain list | grep -q '^nightly'; then
+    return
+  fi
+
+  if ! ${install}; then
+    echo "error: nightly toolchain is required" >&2
+    echo "hint: rerun without --skip-install or run 'rustup toolchain install nightly --profile minimal'" >&2
+    exit 1
+  fi
+
+  rustup toolchain install nightly --profile minimal >/dev/null
+}
+
+main() {
+  local install_tools=true
+  while (($#)); do
+    case "$1" in
+      --skip-install)
+        install_tools=false
+        ;;
+      --help|-h)
+        usage
+        return 0
+        ;;
+      *)
+        echo "error: unknown argument: $1" >&2
+        usage >&2
+        return 1
+        ;;
+    esac
+    shift
+  done
+
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  cd "$repo_root"
+
+  log_step "Ensuring required apt packages"
+  ensure_apt_packages "${install_tools}" pkg-config libseccomp-dev protobuf-compiler jq xxhash
+
+  log_step "Ensuring Rust components"
+  rustup component add rustfmt clippy llvm-tools-preview >/dev/null
+
+  log_step "Ensuring cargo subcommands"
+  ensure_cargo_tool "${install_tools}" cargo-machete cargo-machete
+  ensure_cargo_tool "${install_tools}" cargo-audit cargo-audit
+  ensure_cargo_tool "${install_tools}" cargo-deny cargo-deny
+  ensure_cargo_tool "${install_tools}" cargo-nextest cargo-nextest
+  ensure_cargo_tool "${install_tools}" cargo-udeps cargo-udeps
+  ensure_cargo_tool "${install_tools}" cargo-fuzz cargo-fuzz
+
+  log_step "Ensuring nightly toolchain"
+  ensure_nightly "${install_tools}"
+
+  log_step "Ensuring actionlint"
+  if ! command -v actionlint >/dev/null 2>&1; then
+    echo "error: actionlint is required but not found on PATH" >&2
+    echo "hint: run './repo-setup.sh' or install actionlint manually" >&2
+    exit 1
+  fi
+
+  log_step "Running actionlint"
+  actionlint
+
+  log_step "Running scripts/check_path_versions.sh"
+  ./scripts/check_path_versions.sh
+
+  log_step "Running cargo fmt --all -- --check"
+  cargo fmt --all -- --check
+
+  log_step "Running cargo check --tests --benches"
+  cargo check --tests --benches
+
+  log_step "Running cargo clippy --all-targets --all-features -- -D warnings"
+  cargo clippy --all-targets --all-features -- -D warnings
+
+  log_step "Running cargo nextest run"
+  cargo nextest run
+
+  log_step "Running cargo test"
+  cargo test
+
+  log_step "Running cargo machete"
+  cargo machete
+
+  log_step "Running cargo audit"
+  cargo audit
+
+  log_step "Running cargo deny fetch"
+  cargo deny fetch
+
+  log_step "Running cargo deny check --disable-fetch"
+  cargo deny check --disable-fetch
+
+  log_step "Running cargo +nightly udeps --all-targets --all-features"
+  cargo +nightly udeps --all-targets --all-features
+
+  log_step "Running run_examples.sh"
+  ./run_examples.sh
+
+  log_step "Building fuzz target 'net' with cargo fuzz"
+  cargo +nightly fuzz build net
+
+  log_step "CI parity checks completed successfully"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a scripts/run_ci_checks.sh helper that installs prerequisites (optionally) and runs the full CI validation sequence locally
- document how to trigger the new helper and mirror the GitHub Actions workflow with wrkflw in the README

## Testing
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo check --tests --benches`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `cargo nextest run`
- `cargo audit`
- `cargo deny fetch` *(fails: GitHub advisory database fetch HTTP error)*
- `cargo deny check --disable-fetch` *(fails: advisory database unavailable locally because fetch failed)*
- `./scripts/check_path_versions.sh`
- `./run_examples.sh`
- `cargo +nightly fuzz build net`
- `actionlint`

`cargo +nightly udeps --all-targets --all-features` was not run: installing cargo-udeps exceeded the available time window.

------
https://chatgpt.com/codex/tasks/task_e_68d4bd0f74b08332abe024116b8882b8