### PR TITLE
Align documentation with current example coverage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -12,7 +12,7 @@ Status: Draft for public OSS release
 | CLI workflow (`build`, `run`, `init`, `status`, `report`) | ✅ Complete | `crates/cli` wires policy loading, sandbox orchestration, and reporting, supporting text, JSON, and SARIF outputs. |
 | Agent, metrics, and event export | ✅ Complete | `crates/agent-lite` and `crates/event-reporting` process ring-buffer events, publish Prometheus metrics, and generate SARIF logs. |
 | Test harness and fake sandbox | ✅ Complete | `crates/testkits` and the fake sandbox runtime back CLI integration tests and layout assertions. |
-| Example workspaces | 🟡 In Progress | `examples/network-build`, `examples/spawn-bash`, and `examples/fs-outside-workspace` exist; scenarios for proc-macro load and git clone remain to be added. |
+| Example workspaces | ✅ Complete | Example crates cover network, process launch, filesystem, proc-macro resource abuse, and git clone scenarios. |
 | Documentation set | 🟡 In Progress | README and security model drafts exist; `CONTRIBUTING`, `SECURITY`, `CODEOWNERS`, and PR templates are still outstanding. |
 
 Author: Alex + contributors
@@ -119,7 +119,7 @@ Workspace crates:
 * ✅ `crates/agent-lite` (spec: `qqrm-agent-lite`)
 * ✅ `crates/cli`
 * ✅ `crates/testkits` (spec: `qqrm-testkits`)
-* 🟡 `examples/*` – currently `network-build`, `spawn-bash`, and `fs-outside-workspace`; additional cases (`ex_proc_macro_hog`, `ex_git_clone_https`) remain TODO
+* ✅ `examples/*` – `network-build`, `spawn-bash`, `fs-outside-workspace`, `proc-macro-hog`, and `git-clone-https`
 
 Feature flags:
 
@@ -354,11 +354,11 @@ Levels:
 
 Examples:
 
-* `ex_net_curl_buildrs` – network call in `build.rs`.
-* `ex_exec_bash_buildrs` – attempt to run `bash`.
-* `ex_fs_outside_workspace` – write to `$HOME` and `/tmp`.
-* `ex_proc_macro_hog` – heavy proc macro.
-* `ex_git_clone_https` – `git clone` in `build.rs`.
+* `qqrm-network-build` (`examples/network-build`) – network call in `build.rs`.
+* `qqrm-spawn-bash` (`examples/spawn-bash`) – attempt to run `bash`.
+* `qqrm-fs-outside-workspace` (`examples/fs-outside-workspace`) – write to `$HOME` and `/tmp`.
+* `qqrm-proc-macro-hog` (`examples/proc-macro-hog`) – heavy proc macro stress test.
+* `qqrm-git-clone-https` (`examples/git-clone-https`) – `git clone` in `build.rs`.
 
 CI:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,9 @@ spawn blocked: Permission denied (os error 1)
 == fs-outside-workspace ==
 warning: write outside workspace blocked as expected: Operation not permitted (os error 1)
 
+== ex_proc_macro_hog ==
+warning: cargo-warden detected a simulated proc-macro resource hog
+
 == ex_git_clone_https ==
 warning: git clone blocked as expected: fatal: unable to access 'https://127.0.0.1:9/cargo-warden-denied/': Failed to connect to 127.0.0.1 port 9: Connection refused
 ```


### PR DESCRIPTION
## Summary
- mark the example workspace suite as complete in the specification and list the current crates explicitly
- refresh the examples README snippet so it reflects the proc-macro hog warning emitted by the helper script

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable in container, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d4de0a038c8332a4097b2add40cf79