### PR TITLE
Add contribution and security documentation assets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Summary
+
+- Describe the motivation for this change.
+- Link related issues or specifications.
+
+# Validation
+
+- [ ] `cargo fmt --all`
+- [ ] `cargo check --tests --benches`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test`
+- [ ] `cargo machete`
+- [ ] `./scripts/check_path_versions.sh`
+- [ ] `wrkflw validate`
+- [ ] `wrkflw run .github/workflows/ci.yml`
+
+# Additional Notes
+
+- Call out breaking changes or follow-up work.
+- Mention documentation updates or migration steps if required.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owners for the cargo-warden repository
+* @qqrm
+
+# Core crates
+crates/ @qqrm
+examples/ @qqrm
+fuzz/ @qqrm
+scripts/ @qqrm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# CONTRIBUTING
+
+Thank you for helping us harden cargo-warden. This document explains how to set up your environment, propose changes, and keep the security posture intact.
+
+## Getting Started
+
+1. Install the required toolchain and repository tooling by running:
+
+```bash
+./repo-setup.sh
+```
+
+2. Configure GitHub CLI access so you can inspect workflows and automation:
+
+```bash
+gh auth status
+gh run list --limit 5
+```
+
+3. Fetch the latest changes and create a fresh feature branch from `main` for every task. Branch names should be short, hyphenated English descriptions (for example, `policy-validator-fix`).
+
+## Development Workflow
+
+1. Keep commits focused and include descriptive English messages.
+2. Follow the project layout and module boundaries documented in `SPEC.md` and the crate-level READMEs.
+3. Write code in English, and prefer small, reviewable changes.
+4. Update or add tests whenever behaviour changes. Remove dead code instead of suppressing warnings.
+
+## Mandatory Checks
+
+Every contribution must pass the full validation suite before you submit it for review. Run all commands from the workspace root:
+
+```bash
+cargo fmt --all
+cargo check --tests --benches
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+cargo machete
+./scripts/check_path_versions.sh
+```
+
+Resolve any failures before continuing. If you add new tooling, document it in this file and in the relevant crate README.
+
+## Documentation Standards
+
+- Markdown files use uppercase filenames with underscores (for example, `END_TO_END_TUTORIAL.md`).
+- Always start headings with `#` and specify the language for code blocks (` ```bash `, ` ```rust `, and so on).
+- Keep documentation in English and update references when APIs or CLI flows change.
+
+## Workflow Automation
+
+Mirror the CI pipelines locally to match GitHub Actions:
+
+```bash
+wrkflw validate
+wrkflw run .github/workflows/ci.yml
+```
+
+Refer to recent workflow history with:
+
+```bash
+gh run list --limit 5
+```
+
+Escalate flakes or infrastructure issues with logs so maintainers can triage quickly.
+
+## Reviewing and Merging
+
+1. Open draft pull requests early if you need feedback, but keep automated checks green before requesting review.
+2. Mention any deviations from the standard workflow and justify them in the PR description.
+3. Ensure your branch is rebased on top of the latest `main` before final review.
+4. After approval, maintainers will merge using the standard fast-forward workflow.
+
+## Communication
+
+- Use GitHub issues or discussions for feature requests and bug reports.
+- Keep discussions respectful and actionable.
+- For security-sensitive reports, follow the process documented in `SECURITY.md`.
+
+We appreciate every contribution that makes cargo-warden more reliable and secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# SECURITY POLICY
+
+## Supported Versions
+
+Cargo-warden is currently in active development. We respond to vulnerability reports for the latest `main` branch and the most recent tagged release. Older versions may not receive fixes unless a maintainer explicitly backports a patch.
+
+## Reporting a Vulnerability
+
+1. **Do not** open a public GitHub issue for security vulnerabilities.
+2. Submit a private advisory through the GitHub Security Advisory workflow for `qqrm/cargo-warden` or email the maintainers at `security@cargo-warden.dev`.
+3. Include as much detail as possible:
+   - Affected components or crates
+   - Steps to reproduce the issue
+   - Potential impact and any available mitigations
+   - Suggested fixes, if you have them
+4. Expect an acknowledgement within three business days. If you do not receive a response, follow up on the same channel to ensure the report was received.
+
+## Vulnerability Handling Process
+
+1. Triage and reproduce the reported issue.
+2. Coordinate on a fix in a private branch, adding regression tests whenever possible.
+3. Prepare a security advisory with mitigation steps and patch availability.
+4. Release patched versions and notify reporters before public disclosure.
+
+## Safe Disclosure Guidelines
+
+- Limit distribution of exploit details until a fix is available.
+- Avoid discussing vulnerabilities in public chats, issues, or pull requests before coordinated disclosure.
+- Credit reporters in the advisory when they consent to disclosure.
+
+Thank you for helping us keep cargo-warden users safe.

--- a/SPEC.md
+++ b/SPEC.md
@@ -13,7 +13,7 @@ Status: Draft for public OSS release
 | Agent, metrics, and event export | ✅ Complete | `crates/agent-lite` and `crates/event-reporting` process ring-buffer events, publish Prometheus metrics, and generate SARIF logs. |
 | Test harness and fake sandbox | ✅ Complete | `crates/testkits` and the fake sandbox runtime back CLI integration tests and layout assertions. |
 | Example workspaces | ✅ Complete | Example crates cover network, process launch, filesystem, proc-macro resource abuse, and git clone scenarios. |
-| Documentation set | 🟡 In Progress | README and security model drafts exist; `CONTRIBUTING`, `SECURITY`, `CODEOWNERS`, and PR templates are still outstanding. |
+| Documentation set | ✅ Complete | README, security model, contributing guide, security policy, CODEOWNERS, and PR templates are available. |
 
 Author: Alex + contributors
 Core project license: MIT or Apache-2.0


### PR DESCRIPTION
## Summary
- add a contributor workflow guide covering setup, required checks, and review etiquette F:CONTRIBUTING.md#L1-L80
- publish a security policy with private disclosure instructions and update the specification to mark documentation complete F:SECURITY.md#L1-L31 F:SPEC.md#L8-L16
- register repository ownership defaults and supply a pull request template aligned with the validation suite F:CODEOWNERS#L1-L8 F:.github/PULL_REQUEST_TEMPLATE.md#L1-L20

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable; command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e0aed2d883329dc386e85198827d