### PR TITLE
Stream event log reading

### DIFF
--- a/crates/cli/src/commands/events.rs
+++ b/crates/cli/src/commands/events.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
@@ -5,20 +6,25 @@ use std::path::Path;
 use event_reporting::EventRecord;
 
 pub(crate) fn read_recent_events(path: &Path, limit: usize) -> io::Result<Vec<EventRecord>> {
-    if !path.exists() {
+    if limit == 0 || !path.exists() {
         return Ok(vec![]);
     }
+
     let file = File::open(path)?;
     let reader = BufReader::new(file);
-    let lines: Vec<String> = reader.lines().collect::<Result<_, _>>()?;
-    let start = lines.len().saturating_sub(limit);
-    let mut events = Vec::new();
-    for line in &lines[start..] {
-        if let Ok(ev) = serde_json::from_str::<EventRecord>(line) {
-            events.push(ev);
+    let mut events = VecDeque::new();
+
+    for line in reader.lines() {
+        let line = line?;
+        if let Ok(event) = serde_json::from_str::<EventRecord>(&line) {
+            if events.len() == limit {
+                events.pop_front();
+            }
+            events.push_back(event);
         }
     }
-    Ok(events)
+
+    Ok(events.into_iter().collect())
 }
 
 #[cfg(test)]
@@ -71,5 +77,65 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].pid, 1);
         assert_eq!(events[1].verdict, 1);
+    }
+
+    #[test]
+    fn read_recent_events_limits_output() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let mut file = File::create(&path).unwrap();
+
+        for idx in 0..5 {
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({
+                    "pid": idx,
+                    "tgid": idx * 10,
+                    "time_ns": idx * 1000,
+                    "unit": 0,
+                    "action": 3,
+                    "verdict": 0,
+                    "container_id": 0,
+                    "caps": 0,
+                    "path_or_addr": format!("/bin/cmd{idx}"),
+                    "needed_perm": ""
+                })
+            )
+            .unwrap();
+        }
+
+        let events = read_recent_events(&path, 2).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].pid, 3);
+        assert_eq!(events[1].pid, 4);
+    }
+
+    #[test]
+    fn read_recent_events_zero_limit() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+        let mut file = File::create(&path).unwrap();
+
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "pid": 1,
+                "tgid": 1,
+                "time_ns": 1,
+                "unit": 0,
+                "action": 1,
+                "verdict": 0,
+                "container_id": 0,
+                "caps": 0,
+                "path_or_addr": "/bin/echo",
+                "needed_perm": ""
+            })
+        )
+        .unwrap();
+
+        let events = read_recent_events(&path, 0).unwrap();
+        assert!(events.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- read event logs iteratively and keep only the requested tail using a ring buffer
- add coverage for limit trimming and zero-limit behavior

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4f60b3a2c8332b1bb6565d813725d