### PR TITLE
Expose policy sources in status output

### DIFF
--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -2,14 +2,16 @@ use std::io;
 use std::path::Path;
 
 use crate::commands::read_recent_events;
+use crate::policy::{PolicySource, PolicySourceKind, collect_policy_status};
+use policy_core::Mode;
 
-pub(crate) fn exec() -> io::Result<()> {
-    let policy_path = Path::new("warden.toml");
-    if policy_path.exists() {
-        println!("active policy: {}", policy_path.display());
-    } else {
-        println!("active policy: none");
-    }
+pub(crate) fn exec(policy_paths: &[String], mode_override: Option<Mode>) -> io::Result<()> {
+    let policy_status = collect_policy_status(policy_paths, mode_override)?;
+    print_policy_sources(&policy_status.sources);
+    println!(
+        "effective mode: {}",
+        mode_to_str(policy_status.effective_mode)
+    );
     let events = read_recent_events(Path::new("warden-events.jsonl"), 10)?;
     if events.is_empty() {
         println!("recent events: none");
@@ -20,4 +22,59 @@ pub(crate) fn exec() -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn print_policy_sources(sources: &[PolicySource]) {
+    if sources.is_empty() {
+        println!("policy sources: none");
+        return;
+    }
+    println!("policy sources:");
+    for source in sources {
+        match &source.kind {
+            PolicySourceKind::Workspace { path, member } => {
+                if let Some(member) = member {
+                    println!(
+                        "- workspace policy: {} (member: {}) [mode: {}]",
+                        path.display(),
+                        member,
+                        mode_to_str(source.mode)
+                    );
+                } else {
+                    println!(
+                        "- workspace policy: {} [mode: {}]",
+                        path.display(),
+                        mode_to_str(source.mode)
+                    );
+                }
+            }
+            PolicySourceKind::LocalFile { path } => {
+                println!(
+                    "- local policy: {} [mode: {}]",
+                    path.display(),
+                    mode_to_str(source.mode)
+                );
+            }
+            PolicySourceKind::CliFile { path } => {
+                println!(
+                    "- CLI policy: {} [mode: {}]",
+                    path.display(),
+                    mode_to_str(source.mode)
+                );
+            }
+            PolicySourceKind::DefaultEmpty => {
+                println!("- built-in defaults [mode: {}]", mode_to_str(source.mode));
+            }
+            PolicySourceKind::ModeOverride => {
+                println!("- CLI mode override [mode: {}]", mode_to_str(source.mode));
+            }
+        }
+    }
+}
+
+fn mode_to_str(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Observe => "observe",
+        Mode::Enforce => "enforce",
+    }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
             }
         }
         Commands::Status => {
-            if let Err(e) = commands::status::exec() {
+            if let Err(e) = commands::status::exec(&cli.policy, cli.mode.map(Mode::from)) {
                 eprintln!("status failed: {e}");
                 exit(1);
             }


### PR DESCRIPTION
## Summary
- show all active policy layers in `cargo warden status`, including workspace and CLI overrides
- share policy metadata between commands via new `PolicyStatus` helpers and cover scenarios with tests
- forward CLI policy arguments to the status command so the report matches real execution

## Testing
- `cargo fmt`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo machete`
- `./scripts/check_path_versions.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d4f4da2120833298130c886e499371