### PR TITLE
Log malformed events and cache cargo metadata

### DIFF
--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -11,11 +11,24 @@ pub(crate) fn exec() -> io::Result<()> {
         println!("active policy: none");
     }
     let events = read_recent_events(Path::new("warden-events.jsonl"), 10)?;
+    if events.skipped_lines > 0 {
+        if let Some(err) = events.last_error.as_deref() {
+            eprintln!(
+                "warning: skipped {} malformed event log line(s): {err}",
+                events.skipped_lines
+            );
+        } else {
+            eprintln!(
+                "warning: skipped {} malformed event log line(s)",
+                events.skipped_lines
+            );
+        }
+    }
     if events.is_empty() {
         println!("recent events: none");
     } else {
         println!("recent events:");
-        for e in events {
+        for e in events.events {
             println!("{}", e);
         }
     }


### PR DESCRIPTION
## Summary
- surface malformed event diagnostics via `RecentEvents` so CLI commands warn when lines are skipped
- ignore corrupt `warden-metrics.json` snapshots with a warning and cover the behavior with a regression test
- reuse a single `cargo metadata` call while building isolation to avoid redundant invocations in workspaces

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4f86f9d8883328fa91a1f56dcfa1d