### PR TITLE
Improve event diagnostics and cache metadata

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -5,4 +5,4 @@ pub mod report;
 pub mod run;
 pub mod status;
 
-pub(crate) use events::read_recent_events;
+pub(crate) use events::{ReadEventsResult, read_recent_events};

--- a/crates/cli/src/commands/status.rs
+++ b/crates/cli/src/commands/status.rs
@@ -13,13 +13,19 @@ pub(crate) fn exec(policy_paths: &[String], mode_override: Option<Mode>) -> io::
         mode_to_str(policy_status.effective_mode)
     );
     let events = read_recent_events(Path::new("warden-events.jsonl"), 10)?;
-    if events.is_empty() {
+    if events.events.is_empty() {
         println!("recent events: none");
     } else {
         println!("recent events:");
-        for e in events {
+        for e in events.events {
             println!("{}", e);
         }
+    }
+    if events.skipped > 0 {
+        println!(
+            "warning: ignored {} malformed event entries while reading the log",
+            events.skipped
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- log and count malformed event log entries, surfacing the counts in status/report output
- tolerate and clean up corrupted metrics snapshots instead of aborting report generation
- cache cargo metadata while setting up isolation so the CLI avoids redundant cargo invocations

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh

------
https://chatgpt.com/codex/tasks/task_e_68d4fe2fabdc83328d0a9e5a10ab4b8b