### PR TITLE
Fix Publish Crates workflow dependencies

### DIFF
--- a/.github/workflows/Publish Crates.yml
+++ b/.github/workflows/Publish Crates.yml
@@ -20,8 +20,18 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git remote
-        run: ./repo_setup.sh
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libseccomp-dev \
+            pkg-config \
+            protobuf-compiler \
+            jq \
+            xxhash
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces --locked


### PR DESCRIPTION
## Summary
- configure the Publish Crates workflow checkout to fetch full history and tags
- inline the system dependency installation so the publish job no longer needs repo_setup.sh

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/Publish Crates.yml *(fails: Docker unavailable; emulation hung until aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d507c04ef483329a6d3e56d58b9fbd