### PR TITLE
Refactor Publish workflow

### DIFF
--- a/.github/workflows/Publish Crates.yml
+++ b/.github/workflows/Publish Crates.yml
@@ -20,21 +20,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Configure git remote
-        run: ./repo_setup.sh
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces --locked
       - name: Publish crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: |
-          set -euo pipefail
-          cargo workspaces publish \
-            --publish-as-is \
-            --no-git-commit \
-            --no-git-tag \
-            --no-git-push \
-            --publish-interval 45 \
-            --skip-published \
-            -y
+        shell: bash
+        run: bash -lc 'set -euo pipefail; cargo workspaces publish --publish-as-is --no-git-tag --no-git-push --publish-interval 45 --skip-published -y'


### PR DESCRIPTION
## Summary
- remove the bootstrap repo setup step from the Publish workflow and fetch the full git history during checkout
- keep publishing in a bash shell and wrap the publish command in a bash invocation for reproducible local runs
- drop the deprecated --no-git-commit flag to match current cargo-workspaces behavior while preserving no-push semantics

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/Publish Crates.yml *(fails: crates.io TLS trust store is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d50a132ebc8332b2733a56791e567e