### PR TITLE
Use cargo_metadata for CLI policy metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1de8bc0aa9e9385ceb3bf0c152e3a9b9544f6c4a912c8ae504e80c1f0368603"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1223,7 @@ name = "qqrm-cargo-warden"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "cargo_metadata",
  "clap",
  "event-reporting",
  "qqrm-bpf-api",
@@ -1477,21 +1510,35 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+cargo_metadata = "0.18"
+
 [patch.crates-io]
 aya = { git = "https://github.com/aya-rs/aya", rev = "30182463bdb6cce592477e66659d5f66f846cfcf" }
 aya-obj = { git = "https://github.com/aya-rs/aya", rev = "30182463bdb6cce592477e66659d5f66f846cfcf" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../../README.md"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+cargo_metadata = { workspace = true }
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = "../sandbox-runtime" }


### PR DESCRIPTION
## Summary
- add the cargo_metadata crate to the workspace and CLI crate dependencies
- replace the custom Cargo metadata structures with cargo_metadata APIs in the CLI policy loader
- update policy helpers and tests to work with cargo_metadata types

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Command not found in PATH: set)*

------
https://chatgpt.com/codex/tasks/task_e_68da2c6e5ac8833292f21f2f02f73dae