### PR TITLE
Stream CLI event parsing with serde-jsonlines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ dependencies = [
  "qqrm-testkits",
  "semver",
  "serde",
+ "serde-jsonlines",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1485,6 +1486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-jsonlines"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = "../sandbox-runtime" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde-jsonlines = "0.7"
 semver = "1"
 toml = "0.8"
 event-reporting = { version = "0.1.0", path = "../event-reporting" }


### PR DESCRIPTION
## Summary
- add the serde-jsonlines dependency to the CLI crate
- stream CLI event log parsing through JsonLinesReader while counting malformed records

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test -p qqrm-cargo-warden
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: missing nightly tooling and cargo subcommands in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68da2c829b4c8332b7ddd5cfcd5f5f83