### PR TITLE
Replace env test guards with scoped-env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "qqrm-policy-core",
  "qqrm-sandbox-runtime",
  "qqrm-testkits",
+ "scoped-env",
  "semver",
  "serde",
  "serde_json",
@@ -1260,6 +1261,7 @@ dependencies = [
  "qqrm-bpf-api",
  "qqrm-policy-compiler",
  "qqrm-policy-core",
+ "scoped-env",
  "serde",
  "serde_json",
 ]
@@ -1459,6 +1461,12 @@ checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
 ]
+
+[[package]]
+name = "scoped-env"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86338a78d9058ae1bb70bf4ec558e9c51c611b443a356f7d041d29bb6c1c026"
 
 [[package]]
 name = "scopeguard"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,6 +25,7 @@ event-reporting = { version = "0.1.0", path = "../event-reporting" }
 serial_test = "3"
 assert_cmd = "2"
 tempfile = "3"
+scoped-env = "2.1.0"
 bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
 qqrm-testkits = { version = "0.1.0", path = "../testkits" }
 

--- a/crates/cli/src/policy.rs
+++ b/crates/cli/src/policy.rs
@@ -926,10 +926,10 @@ struct CargoPackageMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{DirGuard, EnvVarGuard};
+    use crate::test_support::{DirGuard, ScopedEnv};
     use bpf_api::{FS_READ, FS_WRITE};
     use serial_test::serial;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::fs::{self, write};
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::path::Path;
@@ -998,11 +998,15 @@ mod tests {
         write(dir.join("src/lib.rs"), "pub fn fixture() {}\n").unwrap();
     }
 
-    fn guard_build_env() -> (EnvVarGuard, EnvVarGuard, EnvVarGuard) {
+    fn guard_build_env() -> (
+        ScopedEnv<&'static OsStr>,
+        ScopedEnv<&'static OsStr>,
+        ScopedEnv<&'static OsStr>,
+    ) {
         (
-            EnvVarGuard::unset("OUT_DIR"),
-            EnvVarGuard::unset("CARGO_TARGET_DIR"),
-            EnvVarGuard::unset("CARGO_TARGET_TMPDIR"),
+            ScopedEnv::remove(OsStr::new("OUT_DIR")),
+            ScopedEnv::remove(OsStr::new("CARGO_TARGET_DIR")),
+            ScopedEnv::remove(OsStr::new("CARGO_TARGET_TMPDIR")),
         )
     }
 
@@ -1332,7 +1336,10 @@ exec.default = "allow"
 
         let out_dir_path = dir.path().join("custom-out");
         fs::create_dir_all(&out_dir_path).unwrap();
-        let out_guard = EnvVarGuard::set("OUT_DIR", out_dir_path.as_os_str().to_os_string());
+        let out_guard = ScopedEnv::set(
+            OsString::from("OUT_DIR"),
+            out_dir_path.as_os_str().to_os_string(),
+        );
 
         let isolation = setup_isolation(&[], &[], None).unwrap();
         drop(out_guard);
@@ -1503,8 +1510,10 @@ permissions = ["env:read:PLUGIN_SETTINGS"]
         let config_dir = dir.path().join("config");
         let trust_path = config_dir.join("cargo-warden").join("trust.json");
         fs::create_dir_all(trust_path.parent().unwrap()).unwrap();
-        let _config_guard =
-            EnvVarGuard::set("XDG_CONFIG_HOME", OsString::from(config_dir.as_os_str()));
+        let _config_guard = ScopedEnv::set(
+            OsString::from("XDG_CONFIG_HOME"),
+            OsString::from(config_dir.as_os_str()),
+        );
 
         write(
             &trust_path,
@@ -1539,8 +1548,10 @@ permissions = ["env:read:PLUGIN_SETTINGS"]
     fn load_trust_db_ignores_missing_file() {
         let dir = tempfile::tempdir().unwrap();
         let config_dir = dir.path().join("cfg");
-        let _config_guard =
-            EnvVarGuard::set("XDG_CONFIG_HOME", OsString::from(config_dir.as_os_str()));
+        let _config_guard = ScopedEnv::set(
+            OsString::from("XDG_CONFIG_HOME"),
+            OsString::from(config_dir.as_os_str()),
+        );
 
         assert!(super::load_trust_db().unwrap().is_none());
     }

--- a/crates/cli/src/test_support.rs
+++ b/crates/cli/src/test_support.rs
@@ -1,5 +1,6 @@
-use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+
+pub(crate) use scoped_env::ScopedEnv;
 
 pub(crate) struct DirGuard {
     original: PathBuf,
@@ -16,52 +17,5 @@ impl DirGuard {
 impl Drop for DirGuard {
     fn drop(&mut self) {
         let _ = std::env::set_current_dir(&self.original);
-    }
-}
-
-pub(crate) struct EnvVarGuard {
-    key: String,
-    previous: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    pub(crate) fn set(key: &str, value: OsString) -> Self {
-        let previous = std::env::var_os(key);
-        unsafe {
-            // SAFETY: tests invoke these helpers in a single-threaded context.
-            std::env::set_var(key, &value);
-        }
-        Self {
-            key: key.to_owned(),
-            previous,
-        }
-    }
-
-    pub(crate) fn unset(key: &str) -> Self {
-        let previous = std::env::var_os(key);
-        unsafe {
-            // SAFETY: tests invoke these helpers in a single-threaded context.
-            std::env::remove_var(key);
-        }
-        Self {
-            key: key.to_owned(),
-            previous,
-        }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(value) = self.previous.take() {
-            unsafe {
-                // SAFETY: tests invoke these helpers in a single-threaded context.
-                std::env::set_var(&self.key, value);
-            }
-        } else {
-            unsafe {
-                // SAFETY: tests invoke these helpers in a single-threaded context.
-                std::env::remove_var(&self.key);
-            }
-        }
     }
 }

--- a/crates/sandbox-runtime/Cargo.toml
+++ b/crates/sandbox-runtime/Cargo.toml
@@ -19,3 +19,6 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[dev-dependencies]
+scoped-env = "2.1.0"


### PR DESCRIPTION
## Summary
- bump the `scoped-env` dev dependency to v2.1.0 for the CLI and sandbox runtime crates
- replace the remaining bespoke environment guard usage with `scoped_env::ScopedEnv` helpers in tests
- adjust test helpers to re-export `ScopedEnv` and rely on `OsStr` conversions instead of ad hoc strings

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable in container)*
- cargo test -p qqrm-cargo-warden
- cargo test -p qqrm-sandbox-runtime

------
https://chatgpt.com/codex/tasks/task_e_68da2c7ce9ec833289c8a2d4825cdc76