### PR TITLE
Derive TestkitError with thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1584,15 +1585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1592,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/testkits/Cargo.toml
+++ b/crates/testkits/Cargo.toml
@@ -17,3 +17,4 @@ sandbox-runtime = { package = "qqrm-sandbox-runtime", version = "0.1.0", path = 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+thiserror = "1"

--- a/crates/testkits/src/lib.rs
+++ b/crates/testkits/src/lib.rs
@@ -49,7 +49,6 @@ use event_reporting::EventRecord;
 use policy_core::Mode;
 use sandbox_runtime::{FsRuleSnapshot, LayoutSnapshot};
 use serde::de::DeserializeOwned;
-use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -57,6 +56,7 @@ use std::process;
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
+use thiserror::Error;
 
 /// Convenient alias for results produced by the testkits helpers.
 pub type Result<T> = std::result::Result<T, TestkitError>;
@@ -70,51 +70,20 @@ const MAX_ATTEMPTS: usize = 50;
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 /// Error returned by the integration testing helpers.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TestkitError {
     /// Wrapper around [`io::Error`].
-    Io(io::Error),
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
     /// Wrapper around [`serde_json::Error`].
-    Json(serde_json::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
     /// The fake sandbox did not produce the expected output in time.
+    #[error("timeout waiting for {path}: {message}", path = .path.display())]
     Timeout { path: PathBuf, message: String },
     /// Assertion helper triggered an error.
+    #[error("assertion failure: {message}")]
     Assertion { message: String },
-}
-
-impl fmt::Display for TestkitError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io(err) => write!(f, "io error: {err}"),
-            Self::Json(err) => write!(f, "json error: {err}"),
-            Self::Timeout { path, message } => {
-                write!(f, "timeout waiting for {}: {message}", path.display())
-            }
-            Self::Assertion { message } => write!(f, "assertion failure: {message}"),
-        }
-    }
-}
-
-impl std::error::Error for TestkitError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(err) => Some(err),
-            Self::Json(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<io::Error> for TestkitError {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
-    }
-}
-
-impl From<serde_json::Error> for TestkitError {
-    fn from(err: serde_json::Error) -> Self {
-        Self::Json(err)
-    }
 }
 
 /// Temporary cargo workspace for integration tests.


### PR DESCRIPTION
## Summary
- derive `TestkitError` with `thiserror::Error` and annotate variants
- add the `thiserror` dependency to the testkits crate

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run --runtime emulation .github/workflows/CI.yml *(aborted: command hung in emulation mode)*

------
https://chatgpt.com/codex/tasks/task_e_68da44a4e6488332a4087b93e8f031d6