### PR TITLE
Replace BPF API runtime tests with const assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,17 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +447,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1384,6 +1384,9 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "qqrm-bpf-core"
@@ -1741,15 +1744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1751,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
@@ -1853,6 +1856,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
+static_assertions = "1.1"

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use static_assertions::const_assert_eq;
+
 /// Bit flag for read access.
 pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
@@ -108,43 +110,10 @@ pub struct Event {
     pub needed_perm: [u8; 64],
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use core::mem::size_of;
-
-    #[test]
-    fn exec_allow_entry_size() {
-        assert_eq!(size_of::<ExecAllowEntry>(), 256);
-    }
-
-    #[test]
-    fn net_rule_size() {
-        assert_eq!(size_of::<NetRule>(), 20);
-    }
-
-    #[test]
-    fn net_rule_entry_size() {
-        assert_eq!(size_of::<NetRuleEntry>(), 24);
-    }
-
-    #[test]
-    fn net_parent_entry_size() {
-        assert_eq!(size_of::<NetParentEntry>(), 8);
-    }
-
-    #[test]
-    fn fs_rule_size() {
-        assert_eq!(size_of::<FsRule>(), 260);
-    }
-
-    #[test]
-    fn fs_rule_entry_size() {
-        assert_eq!(size_of::<FsRuleEntry>(), 264);
-    }
-
-    #[test]
-    fn event_size() {
-        assert_eq!(size_of::<Event>(), 360);
-    }
-}
+const_assert_eq!(core::mem::size_of::<ExecAllowEntry>(), 256);
+const_assert_eq!(core::mem::size_of::<NetRule>(), 20);
+const_assert_eq!(core::mem::size_of::<NetRuleEntry>(), 24);
+const_assert_eq!(core::mem::size_of::<NetParentEntry>(), 8);
+const_assert_eq!(core::mem::size_of::<FsRule>(), 260);
+const_assert_eq!(core::mem::size_of::<FsRuleEntry>(), 264);
+const_assert_eq!(core::mem::size_of::<Event>(), 360);


### PR DESCRIPTION
## Summary
- add the static_assertions crate to the BPF API crate to support compile-time size checks
- replace runtime size tests that depended on `core::mem::size_of` with `const_assert_eq!`

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68da4603ee44833299985d515473a225