### PR TITLE
Simplify sandbox workload case-insensitive checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,17 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +447,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1479,6 +1479,7 @@ dependencies = [
  "scoped-env",
  "serde",
  "serde_json",
+ "unicase",
 ]
 
 [[package]]
@@ -1741,15 +1742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1749,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
@@ -2198,6 +2199,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/sandbox-runtime/Cargo.toml
+++ b/crates/sandbox-runtime/Cargo.toml
@@ -19,6 +19,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+unicase = "2.8"
 
 [dev-dependencies]
 scoped-env = "2.1.0"


### PR DESCRIPTION
## Summary
- add unicase to the sandbox runtime for case-insensitive comparisons
- replace manual ASCII case-matching loops with UniCase helpers for tool detection
- streamline proc-macro argument detection with iterator combinators

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh

------
https://chatgpt.com/codex/tasks/task_e_68da462a29b4833293739735e8651658