### PR TITLE
Use bytemuck for policy compiler serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,17 +449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +467,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1384,6 +1404,9 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "qqrm-bpf-core"
@@ -1438,6 +1461,7 @@ version = "0.1.0"
 name = "qqrm-policy-compiler"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "qqrm-bpf-api",
  "qqrm-policy-core",
  "thiserror 1.0.69",
@@ -1741,15 +1765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1772,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
+bytemuck = { version = "1.15", features = ["derive"] }

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use bytemuck::{Pod, Zeroable};
+
 /// Bit flag for read access.
 pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
@@ -37,13 +39,13 @@ pub const MODE_FLAG_OBSERVE: u32 = 0;
 pub const MODE_FLAG_ENFORCE: u32 = 1;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct ExecAllowEntry {
     pub path: [u8; 256],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct NetRule {
     pub addr: [u8; 16],
     pub protocol: u8,
@@ -52,21 +54,21 @@ pub struct NetRule {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct NetRuleEntry {
     pub unit: u32,
     pub rule: NetRule,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct NetParentEntry {
     pub child: u32,
     pub parent: u32,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct FsRule {
     pub access: u8,
     pub reserved: [u8; 3],
@@ -74,14 +76,14 @@ pub struct FsRule {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable, Pod)]
 pub struct FsRuleEntry {
     pub unit: u32,
     pub rule: FsRule,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Zeroable)]
 /// Event emitted by BPF programs.
 pub struct Event {
     /// Thread identifier (kernel PID).

--- a/crates/policy-compiler/Cargo.toml
+++ b/crates/policy-compiler/Cargo.toml
@@ -13,3 +13,4 @@ readme = "../../README.md"
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
 thiserror = "1.0"
+bytemuck = "1.15"

--- a/crates/policy-compiler/src/lib.rs
+++ b/crates/policy-compiler/src/lib.rs
@@ -7,6 +7,7 @@ use bpf_api::{
     ExecAllowEntry, FS_READ, FS_WRITE, FsRule, FsRuleEntry, MODE_FLAG_ENFORCE, MODE_FLAG_OBSERVE,
     NetParentEntry, NetRule, NetRuleEntry,
 };
+use bytemuck::Pod;
 use policy_core::{ExecDefault, FsDefault, Mode, NetDefault, Policy};
 use thiserror::Error;
 
@@ -199,9 +200,8 @@ fn fill_path_bytes(path: &str) -> Option<[u8; 256]> {
     Some(buf)
 }
 
-fn slice_to_bytes<T: Copy>(slice: &[T]) -> Vec<u8> {
-    let len = core::mem::size_of_val(slice);
-    unsafe { core::slice::from_raw_parts(slice.as_ptr() as *const u8, len).to_vec() }
+fn slice_to_bytes<T: Pod>(slice: &[T]) -> Vec<u8> {
+    bytemuck::cast_slice(slice).to_vec()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add bytemuck to the policy compiler and BPF API crates to support safe byte casting
- derive Pod/Zeroable for the BPF API map entry structs and leave Event zeroable-only
- replace the policy compiler's slice_to_bytes helper with bytemuck::cast_slice while keeping map binaries unchanged

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable in workspace, aborted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68da4623085883328ed98d8c31b88502