### PR TITLE
Refactor RawPolicy conversion to use iterator extensions

### DIFF
--- a/crates/policy-core/src/raw.rs
+++ b/crates/policy-core/src/raw.rs
@@ -53,32 +53,20 @@ impl From<RawPolicy> for Policy {
         } = allow;
 
         let mut fs_rules = FsRules::with_default(fs.default);
-        for path in read_extra {
-            fs_rules.insert_read_raw(path);
-        }
-        for path in write_extra {
-            fs_rules.insert_write_raw(path);
-        }
+        fs_rules.extend_reads(read_extra.into_iter().chain(std::iter::empty()));
+        fs_rules.extend_writes(write_extra.into_iter().chain(std::iter::empty()));
 
         let mut net_rules = NetRules::with_default(net.default);
-        for host in hosts {
-            net_rules.insert_raw(host);
-        }
+        net_rules.extend(hosts.into_iter().chain(std::iter::empty()));
 
         let mut exec_rules = ExecRules::with_default(exec.default);
-        for bin in exec_allowed {
-            exec_rules.insert_raw(bin);
-        }
+        exec_rules.extend(exec_allowed.into_iter().chain(std::iter::empty()));
 
         let mut syscall_rules = SyscallRules::default();
-        for name in syscall.deny {
-            syscall_rules.insert_raw(name);
-        }
+        syscall_rules.extend(syscall.deny.into_iter().chain(std::iter::empty()));
 
         let mut env_rules = EnvRules::default();
-        for var in env_read {
-            env_rules.insert_raw(var);
-        }
+        env_rules.extend(env_read.into_iter().chain(std::iter::empty()));
 
         Policy {
             mode,

--- a/crates/policy-core/src/rules.rs
+++ b/crates/policy-core/src/rules.rs
@@ -113,15 +113,6 @@ where
         }
     }
 
-    pub(crate) fn extend<I>(&mut self, iter: I)
-    where
-        I: IntoIterator<Item = T>,
-    {
-        for value in iter {
-            self.insert(value);
-        }
-    }
-
     pub(crate) fn merge(&mut self, other: Self) {
         self.values.extend(other.values);
         self.duplicates.extend(other.duplicates);
@@ -173,7 +164,9 @@ macro_rules! define_duplicate_rules {
             where
                 I: IntoIterator<Item = $value_ty>,
             {
-                self.$field.extend(iter);
+                for value in iter {
+                    self.insert_raw(value);
+                }
             }
 
             pub(crate) fn merge(&mut self, other: $name) {
@@ -217,7 +210,9 @@ macro_rules! define_duplicate_rules {
             where
                 I: IntoIterator<Item = $value_ty>,
             {
-                self.$field.extend(iter);
+                for value in iter {
+                    self.insert_raw(value);
+                }
             }
 
             pub(crate) fn merge(&mut self, other: $name) {


### PR DESCRIPTION
## Summary
- replace the RawPolicy conversion loops with iterator-based `extend` calls
- route duplicate-aware rule extension through `insert_raw` to preserve duplicate tracking

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable and emulation hung, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68da462572788332a649908b72fdb651