### PR TITLE
Refactor host test maps to use safe containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,17 +435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +453,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1397,6 +1403,9 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-host"
 version = "0.1.0"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "qqrm-cargo-warden"
@@ -1741,15 +1750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1757,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]

--- a/crates/bpf-host/Cargo.toml
+++ b/crates/bpf-host/Cargo.toml
@@ -10,3 +10,4 @@ documentation = "https://docs.rs/qqrm-bpf-host"
 readme = "../../README.md"
 
 [dependencies]
+arrayvec = "0.7"

--- a/crates/bpf-host/src/lib.rs
+++ b/crates/bpf-host/src/lib.rs
@@ -1,11 +1,13 @@
 //! Host-only shims for exercising qqrm-bpf-core programs outside the kernel.
 
 pub mod maps {
-    use core::cell::UnsafeCell;
+    use arrayvec::ArrayVec;
+    use core::cell::RefCell;
+    use std::sync::{Mutex, MutexGuard};
 
     /// Simplified fixed-size array map used by tests and fuzzers.
     pub struct TestArray<T: Copy, const N: usize> {
-        data: UnsafeCell<[Option<T>; N]>,
+        data: RefCell<ArrayVec<Option<T>, N>>,
     }
 
     unsafe impl<T: Copy, const N: usize> Sync for TestArray<T, N> {}
@@ -20,7 +22,7 @@ pub mod maps {
         /// Creates an empty map instance.
         pub const fn new() -> Self {
             Self {
-                data: UnsafeCell::new([None; N]),
+                data: RefCell::new(ArrayVec::new_const()),
             }
         }
 
@@ -30,7 +32,7 @@ pub mod maps {
             if idx >= N {
                 return None;
             }
-            unsafe { (*self.data.get())[idx] }
+            self.data.borrow().get(idx).copied().flatten()
         }
 
         /// Writes an entry if the index is in range.
@@ -39,17 +41,18 @@ pub mod maps {
             if idx >= N {
                 return;
             }
-            unsafe {
-                (*self.data.get())[idx] = Some(value);
+            let mut data = self.data.borrow_mut();
+            while data.len() <= idx {
+                data.push(None);
             }
+            data[idx] = Some(value);
         }
 
         /// Clears all entries in place.
         pub fn clear(&self) {
-            unsafe {
-                for slot in (*self.data.get()).iter_mut() {
-                    *slot = None;
-                }
+            let mut data = self.data.borrow_mut();
+            for slot in data.iter_mut() {
+                *slot = None;
             }
         }
     }
@@ -73,7 +76,7 @@ pub mod maps {
 
     /// Simplified hash map implementation for host-based tests.
     pub struct TestHashMap<K: Copy + PartialEq, V: Copy, const N: usize> {
-        data: UnsafeCell<[Option<(K, V)>; N]>,
+        data: Mutex<ArrayVec<(K, V), N>>,
     }
 
     unsafe impl<K: Copy + PartialEq, V: Copy, const N: usize> Sync for TestHashMap<K, V, N> {}
@@ -88,62 +91,54 @@ pub mod maps {
         /// Creates an empty hash map instance.
         pub const fn new() -> Self {
             Self {
-                data: UnsafeCell::new([None; N]),
+                data: Mutex::new(ArrayVec::new_const()),
             }
         }
 
         /// Retrieves a value for the provided key when it exists.
         pub fn get(&self, key: K) -> Option<V> {
-            unsafe {
-                (*self.data.get()).iter().find_map(|slot| {
-                    slot.and_then(
-                        |(stored, value)| {
-                            if stored == key { Some(value) } else { None }
-                        },
-                    )
-                })
-            }
+            let slots = self.lock();
+            slots
+                .iter()
+                .find_map(|(stored, value)| if *stored == key { Some(*value) } else { None })
         }
 
         /// Inserts or updates the value for the provided key.
         pub fn insert(&self, key: K, value: V) {
-            unsafe {
-                let slots = &mut *self.data.get();
-                for slot in slots.iter_mut() {
-                    if let Some((stored, _)) = slot
-                        && *stored == key
-                    {
-                        *slot = Some((key, value));
-                        return;
-                    }
-                }
-                if let Some(empty) = slots.iter_mut().find(|slot| slot.is_none()) {
-                    *empty = Some((key, value));
-                    return;
-                }
-                if let Some(slot) = slots.first_mut() {
-                    *slot = Some((key, value));
-                }
+            let mut slots = self.lock();
+            if let Some(existing) = slots.iter_mut().find(|(stored, _)| *stored == key) {
+                *existing = (key, value);
+                return;
+            }
+            if slots.len() < N {
+                slots.push((key, value));
+            } else if let Some(slot) = slots.first_mut() {
+                *slot = (key, value);
             }
         }
 
         /// Removes the value associated with the provided key.
         pub fn remove(&self, key: K) {
-            unsafe {
-                for slot in (*self.data.get()).iter_mut() {
-                    if slot.map(|(stored, _)| stored == key).unwrap_or(false) {
-                        *slot = None;
-                    }
+            let mut slots = self.lock();
+            let mut i = 0;
+            while i < slots.len() {
+                if slots[i].0 == key {
+                    slots.remove(i);
+                } else {
+                    i += 1;
                 }
             }
         }
 
         /// Clears all entries from the hash map.
         pub fn clear(&self) {
-            unsafe {
-                for slot in (*self.data.get()).iter_mut() {
-                    *slot = None;
-                }
+            self.lock().clear();
+        }
+
+        fn lock(&self) -> MutexGuard<'_, ArrayVec<(K, V), N>> {
+            match self.data.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
             }
         }
     }


### PR DESCRIPTION
## Summary
- add arrayvec as the fixed-capacity backing store for the host maps
- wrap the test array and hash map in RefCell/Mutex to remove manual UnsafeCell usage
- adjust map accessors to delegate to ArrayVec while keeping existing semantics

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68da461323548332962d383df127ab55