### PR TITLE
Integrate bytemuck pods and UniCase workload detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1261,10 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
+dependencies = [
+ "aya",
+ "bytemuck",
+]
 
 [[package]]
 name = "qqrm-bpf-core"
@@ -1327,6 +1351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aya",
+ "bytemuck",
  "libc",
  "libseccomp",
  "qqrm-agent-lite",
@@ -1336,6 +1361,7 @@ dependencies = [
  "scoped-env",
  "serde",
  "serde_json",
+ "unicase",
 ]
 
 [[package]]
@@ -1584,15 +1610,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
 name = "serde-jsonlines"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1617,15 @@ checksum = "013e069239d98648ea43a9c01845b381445e88de08b5a895ef9302e3bffde03d"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
 ]
 
 [[package]]
@@ -2014,6 +2040,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/EVENT_LOG_ABI.md
+++ b/EVENT_LOG_ABI.md
@@ -12,7 +12,8 @@ pub struct Event {
     pub unit: u8,        // 0 Other, 1 BuildRs, 2 ProcMacro, 3 Rustc, 4 Linker
     pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
     pub verdict: u8,     // 0 Allowed, 1 Denied
-    pub reserved: u8,    // padding for alignment, reserved for future use
+    pub reserved: u8,    // reserved for future use
+    pub reserved_padding: [u8; 4],
     pub container_id: u64,
     pub caps: u64,       // Linux capability bitmask
     pub path_or_addr: [u8; 256], // null-terminated path or network address

--- a/SPEC.md
+++ b/SPEC.md
@@ -142,6 +142,7 @@ pub struct Event {
   pub action: u8,      // 0 Open, 1 Rename, 2 Unlink, 3 Exec, 4 Connect
   pub verdict: u8,     // 0 Allowed, 1 Denied
   pub reserved: u8,
+  pub reserved_padding: [u8; 4],
   pub container_id: u64,
   pub caps: u64,
   pub path_or_addr: [u8; 256],

--- a/crates/agent-lite/src/lib.rs
+++ b/crates/agent-lite/src/lib.rs
@@ -685,6 +685,7 @@ mod tests {
             action: 2,
             verdict: 0,
             reserved: 0,
+            reserved_padding: [0; 4],
             container_id: 7,
             caps: 1,
             path_or_addr: path,

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -13,4 +13,11 @@ readme = "../../README.md"
 path = "src/lib.rs"
 crate-type = ["lib"]
 
+[features]
+default = []
+std = []
+aya-pod = ["std", "aya"]
+
 [dependencies]
+bytemuck = { version = "1.15", features = ["derive"], default-features = false }
+aya = { version = "0.13", optional = true, default-features = false }

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,4 +1,6 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use bytemuck::{Pod, Zeroable};
 
 /// Bit flag for read access.
 pub const FS_READ: u8 = 1;
@@ -37,13 +39,13 @@ pub const MODE_FLAG_OBSERVE: u32 = 0;
 pub const MODE_FLAG_ENFORCE: u32 = 1;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct ExecAllowEntry {
     pub path: [u8; 256],
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct NetRule {
     pub addr: [u8; 16],
     pub protocol: u8,
@@ -52,21 +54,21 @@ pub struct NetRule {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct NetRuleEntry {
     pub unit: u32,
     pub rule: NetRule,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct NetParentEntry {
     pub child: u32,
     pub parent: u32,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct FsRule {
     pub access: u8,
     pub reserved: [u8; 3],
@@ -74,14 +76,14 @@ pub struct FsRule {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct FsRuleEntry {
     pub unit: u32,
     pub rule: FsRule,
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
 /// Event emitted by BPF programs.
 pub struct Event {
     /// Thread identifier (kernel PID).
@@ -96,8 +98,10 @@ pub struct Event {
     pub action: u8,
     /// Allow (0) or deny (1).
     pub verdict: u8,
-    /// Reserved for future use and alignment.
+    /// Reserved for future use.
     pub reserved: u8,
+    /// Additional padding for alignment; always zeroed.
+    pub reserved_padding: [u8; 4],
     /// Identifier of the container or sandbox.
     pub container_id: u64,
     /// Bitmask of Linux capabilities held by the process.
@@ -107,6 +111,21 @@ pub struct Event {
     /// Suggested policy entry required to permit the operation.
     pub needed_perm: [u8; 64],
 }
+
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for ExecAllowEntry {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for NetRule {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for NetRuleEntry {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for NetParentEntry {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for FsRule {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for FsRuleEntry {}
+#[cfg(feature = "aya-pod")]
+unsafe impl aya::Pod for Event {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -1222,6 +1222,7 @@ fn fs_event(action: u8, path: &[u8; 256], access: u8, allowed: bool) -> Event {
         action,
         verdict: if allowed { 0 } else { 1 },
         reserved: 0,
+        reserved_padding: [0; 4],
         container_id: 0,
         caps: 0,
         path_or_addr: [0; 256],

--- a/crates/sandbox-runtime/Cargo.toml
+++ b/crates/sandbox-runtime/Cargo.toml
@@ -11,7 +11,8 @@ documentation = "https://docs.rs/qqrm-sandbox-runtime"
 [dependencies]
 anyhow = "1"
 aya = "0.13"
-bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api" }
+bpf-api = { package = "qqrm-bpf-api", version = "0.1.0", path = "../bpf-api", features = ["aya-pod"] }
+bytemuck = { version = "1.15", features = ["derive"] }
 libc = "0.2"
 libseccomp = "0.3"
 qqrm-agent-lite = { version = "0.1.0", path = "../agent-lite" }
@@ -19,6 +20,7 @@ qqrm-policy-compiler = { version = "0.1.0", path = "../policy-compiler" }
 policy-core = { package = "qqrm-policy-core", version = "0.1.0", path = "../policy-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+unicase = "2"
 
 [dev-dependencies]
 scoped-env = "2.1.0"


### PR DESCRIPTION
## Summary
- derive bytemuck Pod/Zeroable on the shared BPF API structs and add an optional aya integration feature for consumers
- expose the event padding explicitly, update docs/tests, and load sandbox map arrays without custom pod wrappers
- switch workload unit detection to UniCase helpers and add the unicase/bytemuck dependencies to the sandbox runtime crate

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable and missing `set` command in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68da44a192a88332849c4290bb552937