### PR TITLE
Refactor host BPF map shims to use heapless data structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,17 +435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +453,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -675,6 +681,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +712,16 @@ checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1384,6 +1409,9 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "qqrm-bpf-core"
@@ -1397,6 +1425,9 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-host"
 version = "0.1.0"
+dependencies = [
+ "heapless",
+]
 
 [[package]]
 name = "qqrm-cargo-warden"
@@ -1855,6 +1886,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -18,12 +18,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -78,9 +101,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii"
@@ -206,9 +235,9 @@ dependencies = [
  "hashbrown 0.16.0",
  "libc",
  "log",
- "object 0.37.3",
+ "object",
  "once_cell",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -254,23 +283,23 @@ dependencies = [
  "bytes",
  "hashbrown 0.16.0",
  "log",
- "object 0.37.3",
- "thiserror 2.0.16",
+ "object",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.7",
+ "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -281,12 +310,27 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -316,6 +360,18 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -362,10 +418,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "chunked_transfer"
@@ -375,9 +452,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -385,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -420,12 +497,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -479,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,22 +597,33 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "event-reporting"
 version = "0.1.0"
 dependencies = [
+ "jsonschema",
  "sarif_rust",
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
 ]
 
 [[package]]
@@ -511,10 +633,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "file-rotate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
+dependencies = [
+ "chrono",
+ "flate2",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -541,6 +689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -639,8 +797,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -652,14 +812,14 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -673,7 +833,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.11.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -801,6 +961,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,12 +1103,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -939,10 +1123,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "itertools"
@@ -960,6 +1159,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "clap",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.16",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,9 +1206,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libredox"
@@ -1001,9 +1240,9 @@ checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -1035,9 +1274,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1072,6 +1311,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,22 +1406,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap 2.11.0",
+ "indexmap 2.11.4",
  "memchr",
 ]
 
@@ -1155,7 +1470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.0",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -1204,6 +1519,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1284,17 +1605,17 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
@@ -1388,6 +1709,7 @@ dependencies = [
  "aya",
  "cfg-if",
  "event-reporting",
+ "file-rotate",
  "futures-core",
  "futures-util",
  "libc",
@@ -1427,6 +1749,7 @@ name = "qqrm-bpf-host"
 version = "0.1.0"
 dependencies = [
  "heapless",
+ "spin",
 ]
 
 [[package]]
@@ -1470,6 +1793,7 @@ version = "0.1.0"
 name = "qqrm-policy-compiler"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "qqrm-bpf-api",
  "qqrm-policy-core",
  "thiserror 1.0.69",
@@ -1511,6 +1835,7 @@ dependencies = [
  "scoped-env",
  "serde",
  "serde_json",
+ "unicase",
 ]
 
 [[package]]
@@ -1539,9 +1864,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1642,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1654,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1670,6 +1995,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,15 +2038,15 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1718,7 +2079,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26c4ecd5c2c073292184e0a17d72fef306a4a7d24ec333bcafe2befbb242ec0b"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.4",
  "regex",
  "serde",
  "serde_json",
@@ -1805,14 +2166,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1821,6 +2183,18 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1848,6 +2222,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
@@ -1879,6 +2259,15 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1928,6 +2317,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "systemd-journal-logger"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,15 +2349,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1967,11 +2377,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1987,13 +2397,43 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2109,7 +2549,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.11.4",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2239,10 +2679,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.18"
+name = "unicase"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "url"
@@ -2267,6 +2713,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2300,18 +2756,162 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.1.3"
+name = "wasm-bindgen"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2346,7 +2946,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2382,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
@@ -2545,10 +3154,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.45.0"
+name = "winreg"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
+static_assertions = "1.1"

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use static_assertions::const_assert_eq;
+
 /// Bit flag for read access.
 pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
@@ -108,43 +110,10 @@ pub struct Event {
     pub needed_perm: [u8; 64],
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use core::mem::size_of;
-
-    #[test]
-    fn exec_allow_entry_size() {
-        assert_eq!(size_of::<ExecAllowEntry>(), 256);
-    }
-
-    #[test]
-    fn net_rule_size() {
-        assert_eq!(size_of::<NetRule>(), 20);
-    }
-
-    #[test]
-    fn net_rule_entry_size() {
-        assert_eq!(size_of::<NetRuleEntry>(), 24);
-    }
-
-    #[test]
-    fn net_parent_entry_size() {
-        assert_eq!(size_of::<NetParentEntry>(), 8);
-    }
-
-    #[test]
-    fn fs_rule_size() {
-        assert_eq!(size_of::<FsRule>(), 260);
-    }
-
-    #[test]
-    fn fs_rule_entry_size() {
-        assert_eq!(size_of::<FsRuleEntry>(), 264);
-    }
-
-    #[test]
-    fn event_size() {
-        assert_eq!(size_of::<Event>(), 360);
-    }
-}
+const_assert_eq!(core::mem::size_of::<ExecAllowEntry>(), 256);
+const_assert_eq!(core::mem::size_of::<NetRule>(), 20);
+const_assert_eq!(core::mem::size_of::<NetRuleEntry>(), 24);
+const_assert_eq!(core::mem::size_of::<NetParentEntry>(), 8);
+const_assert_eq!(core::mem::size_of::<FsRule>(), 260);
+const_assert_eq!(core::mem::size_of::<FsRuleEntry>(), 264);
+const_assert_eq!(core::mem::size_of::<Event>(), 360);

--- a/crates/bpf-core/src/lib.rs
+++ b/crates/bpf-core/src/lib.rs
@@ -17,8 +17,15 @@ use bpf_host::{
     fs::{dentry_path_ptr, file_mode_bits, file_path_ptr},
     maps::{DummyRingBuf, TestArray, TestHashMap},
 };
+#[cfg(not(any(target_arch = "bpf", test, feature = "fuzzing")))]
+#[allow(unused_imports)]
+use core::ffi::c_void;
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-use core::{ffi::c_void, mem::size_of};
+use core::{
+    ffi::{CStr, c_void},
+    marker::PhantomData,
+    mem::size_of,
+};
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
 const _EVENT_SIZE: usize = size_of::<Event>();
@@ -57,333 +64,221 @@ fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}
 }
 
-macro_rules! map_type_alias {
-    (@define EXEC_ALLOWLIST, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type ExecAllowlistMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type ExecAllowlistMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define EXEC_ALLOWLIST_LENGTH, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type LengthMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type LengthMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define NET_RULES, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type NetRulesMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type NetRulesMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define NET_PARENTS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type NetParentsMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type NetParentsMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define FS_RULES, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type FsRulesMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type FsRulesMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define EVENT_COUNTS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type EventCountsMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type EventCountsMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define MODE_FLAGS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        type ModeFlagsMap = Array<$value>;
-        #[cfg(any(test, feature = "fuzzing"))]
-        type ModeFlagsMap = TestArray<$value, { ($capacity) as usize }>;
-    };
-    (@define $other:ident, $value:ty, $capacity:expr) => {
-        compile_error!(concat!(
-            "Missing type alias mapping for ",
-            stringify!($other)
-        ));
-    };
-    (@name EXEC_ALLOWLIST) => {
-        ExecAllowlistMap
-    };
-    (@name EXEC_ALLOWLIST_LENGTH) => {
-        LengthMap
-    };
-    (@name NET_RULES) => {
-        NetRulesMap
-    };
-    (@name NET_RULES_LENGTH) => {
-        LengthMap
-    };
-    (@name NET_PARENTS) => {
-        NetParentsMap
-    };
-    (@name NET_PARENTS_LENGTH) => {
-        LengthMap
-    };
-    (@name FS_RULES) => {
-        FsRulesMap
-    };
-    (@name FS_RULES_LENGTH) => {
-        LengthMap
-    };
-    (@name EVENT_COUNTS) => {
-        EventCountsMap
-    };
-    (@name MODE_FLAGS) => {
-        ModeFlagsMap
-    };
-    (@name $other:ident) => {
-        compile_error!(concat!(
-            "Missing type alias mapping for ",
-            stringify!($other)
-        ));
-    };
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+struct ArrayDescriptor<T, const CAPACITY: usize> {
+    name: &'static str,
+    _marker: PhantomData<T>,
 }
 
-macro_rules! map_ctor_fn {
-    (@define EXEC_ALLOWLIST, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn exec_allowlist_map() -> ExecAllowlistMap {
-            Array::with_max_entries($capacity, 0)
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+impl<T: Copy, const CAPACITY: usize> ArrayDescriptor<T, CAPACITY> {
+    const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            _marker: PhantomData,
         }
+    }
 
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn exec_allowlist_map() -> ExecAllowlistMap {
-            TestArray::new()
-        }
-    };
-    (@define EXEC_ALLOWLIST_LENGTH, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn length_map() -> LengthMap {
-            Array::with_max_entries($capacity, 0)
-        }
+    #[cfg(target_arch = "bpf")]
+    const fn bpf_map(&self) -> Array<T> {
+        Array::with_max_entries(CAPACITY as u32, 0)
+    }
 
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn length_map() -> LengthMap {
-            TestArray::new()
-        }
-    };
-    (@define NET_RULES, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn net_rules_map() -> NetRulesMap {
-            Array::with_max_entries($capacity, 0)
-        }
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn host_map(&self) -> TestArray<T, CAPACITY> {
+        TestArray::<T, CAPACITY>::new()
+    }
 
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn net_rules_map() -> NetRulesMap {
-            TestArray::new()
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn map_descriptor(&self, clear: fn()) -> MapDescriptor {
+        MapDescriptor {
+            name: self.name,
+            kind: MapKind::Array {
+                value_size: size_of::<T>() as u32,
+            },
+            capacity: CAPACITY as u32,
+            clear,
         }
-    };
-    (@define NET_PARENTS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn net_parents_map() -> NetParentsMap {
-            Array::with_max_entries($capacity, 0)
-        }
-
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn net_parents_map() -> NetParentsMap {
-            TestArray::new()
-        }
-    };
-    (@define FS_RULES, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn fs_rules_map() -> FsRulesMap {
-            Array::with_max_entries($capacity, 0)
-        }
-
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn fs_rules_map() -> FsRulesMap {
-            TestArray::new()
-        }
-    };
-    (@define EVENT_COUNTS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn event_counts_map() -> EventCountsMap {
-            Array::with_max_entries($capacity, 0)
-        }
-
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn event_counts_map() -> EventCountsMap {
-            TestArray::new()
-        }
-    };
-    (@define MODE_FLAGS, $value:ty, $capacity:expr) => {
-        #[cfg(target_arch = "bpf")]
-        const fn mode_flags_map() -> ModeFlagsMap {
-            Array::with_max_entries($capacity, 0)
-        }
-
-        #[cfg(any(test, feature = "fuzzing"))]
-        const fn mode_flags_map() -> ModeFlagsMap {
-            TestArray::new()
-        }
-    };
-    (@define $other:ident, $value:ty, $capacity:expr) => {
-        compile_error!(concat!(
-            "Missing constructor mapping for ",
-            stringify!($other)
-        ));
-    };
-    (@name EXEC_ALLOWLIST) => {
-        exec_allowlist_map
-    };
-    (@name EXEC_ALLOWLIST_LENGTH) => {
-        length_map
-    };
-    (@name NET_RULES) => {
-        net_rules_map
-    };
-    (@name NET_RULES_LENGTH) => {
-        length_map
-    };
-    (@name NET_PARENTS) => {
-        net_parents_map
-    };
-    (@name NET_PARENTS_LENGTH) => {
-        length_map
-    };
-    (@name FS_RULES) => {
-        fs_rules_map
-    };
-    (@name FS_RULES_LENGTH) => {
-        length_map
-    };
-    (@name EVENT_COUNTS) => {
-        event_counts_map
-    };
-    (@name MODE_FLAGS) => {
-        mode_flags_map
-    };
-    (@name $other:ident) => {
-        compile_error!(concat!(
-            "Missing constructor mapping for ",
-            stringify!($other)
-        ));
-    };
+    }
 }
 
-macro_rules! map_define_alias {
-    (EXEC_ALLOWLIST, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(EXEC_ALLOWLIST, $($rest)*);
-    };
-    (EXEC_ALLOWLIST_LENGTH, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(EXEC_ALLOWLIST_LENGTH, $($rest)*);
-    };
-    (NET_RULES, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(NET_RULES, $($rest)*);
-    };
-    (NET_RULES_LENGTH, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $skip!(NET_RULES_LENGTH, $($rest)*);
-    };
-    (NET_PARENTS, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(NET_PARENTS, $($rest)*);
-    };
-    (NET_PARENTS_LENGTH, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $skip!(NET_PARENTS_LENGTH, $($rest)*);
-    };
-    (FS_RULES, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(FS_RULES, $($rest)*);
-    };
-    (FS_RULES_LENGTH, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $skip!(FS_RULES_LENGTH, $($rest)*);
-    };
-    (EVENT_COUNTS, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(EVENT_COUNTS, $($rest)*);
-    };
-    (MODE_FLAGS, $define:ident, $skip:ident, $($rest:tt)*) => {
-        $define!(MODE_FLAGS, $($rest)*);
-    };
-    ($other:ident, $define:ident, $skip:ident, $($rest:tt)*) => {
-        compile_error!(concat!("Missing alias flag for ", stringify!($other)));
-    };
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+struct HashMapDescriptor<K, V, const CAPACITY: usize> {
+    name: &'static str,
+    _marker: PhantomData<(K, V)>,
 }
 
-macro_rules! define_map {
-    ($ident:ident, $aya_name:literal, $value:ty, $capacity:expr $(,)?) => {
-        map_define_alias!(
-            $ident,
-            define_map_define,
-            define_map_skip,
-            $aya_name,
-            $value,
-            $capacity
-        );
-    };
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+impl<K: Copy + Eq, V: Copy, const CAPACITY: usize> HashMapDescriptor<K, V, CAPACITY> {
+    const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            _marker: PhantomData,
+        }
+    }
+
+    #[cfg(target_arch = "bpf")]
+    const fn bpf_map(&self) -> HashMap<K, V> {
+        HashMap::with_max_entries(CAPACITY as u32, 0)
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn host_map(&self) -> TestHashMap<K, V, CAPACITY> {
+        TestHashMap::<K, V, CAPACITY>::new()
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn map_descriptor(&self, clear: fn()) -> MapDescriptor {
+        MapDescriptor {
+            name: self.name,
+            kind: MapKind::HashMap {
+                key_size: size_of::<K>() as u32,
+                value_size: size_of::<V>() as u32,
+            },
+            capacity: CAPACITY as u32,
+            clear,
+        }
+    }
 }
 
-macro_rules! define_map_define {
-    ($ident:ident, $aya_name:literal, $value:ty, $capacity:expr) => {
-        map_type_alias!(@define $ident, $value, $capacity);
-        map_ctor_fn!(@define $ident, $value, $capacity);
-        define_map_static!($ident, $aya_name);
-    };
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+struct RingBufDescriptor<const BYTE_SIZE: usize> {
+    name: &'static str,
 }
 
-macro_rules! define_map_skip {
-    ($ident:ident, $aya_name:literal, $value:ty, $capacity:expr) => {
-        define_map_static!($ident, $aya_name);
-    };
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+impl<const BYTE_SIZE: usize> RingBufDescriptor<BYTE_SIZE> {
+    const fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+
+    #[cfg(target_arch = "bpf")]
+    const fn bpf_map(&self) -> RingBuf {
+        RingBuf::with_byte_size(BYTE_SIZE as u32, 0)
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn host_map(&self) -> DummyRingBuf {
+        DummyRingBuf::new()
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    const fn map_descriptor(&self, clear: fn()) -> MapDescriptor {
+        MapDescriptor {
+            name: self.name,
+            kind: MapKind::RingBuf {
+                byte_size: BYTE_SIZE as u32,
+            },
+            capacity: BYTE_SIZE as u32,
+            clear,
+        }
+    }
 }
-
-macro_rules! define_map_static {
-    ($ident:ident, $aya_name:literal) => {
-        #[cfg(target_arch = "bpf")]
-        #[map(name = $aya_name)]
-static mut $ident: map_type_alias!(@name $ident) = map_ctor_fn!(@name $ident)();
-
-        #[cfg(any(test, feature = "fuzzing"))]
-static $ident: map_type_alias!(@name $ident) = map_ctor_fn!(@name $ident)();
-    };
-}
-
-define_map!(
-    EXEC_ALLOWLIST,
-    "EXEC_ALLOWLIST",
-    bpf_api::ExecAllowEntry,
-    bpf_api::EXEC_ALLOWLIST_CAPACITY,
-);
-define_map!(EXEC_ALLOWLIST_LENGTH, "EXEC_ALLOWLIST_LENGTH", u32, 1);
-define_map!(
-    NET_RULES,
-    "NET_RULES",
-    bpf_api::NetRuleEntry,
-    bpf_api::NET_RULES_CAPACITY,
-);
-define_map!(NET_RULES_LENGTH, "NET_RULES_LENGTH", u32, 1);
-define_map!(
-    NET_PARENTS,
-    "NET_PARENTS",
-    bpf_api::NetParentEntry,
-    bpf_api::NET_PARENTS_CAPACITY,
-);
-define_map!(NET_PARENTS_LENGTH, "NET_PARENTS_LENGTH", u32, 1);
-define_map!(
-    FS_RULES,
-    "FS_RULES",
-    bpf_api::FsRuleEntry,
-    bpf_api::FS_RULES_CAPACITY,
-);
-define_map!(FS_RULES_LENGTH, "FS_RULES_LENGTH", u32, 1);
-define_map!(
-    EVENT_COUNTS,
-    "EVENT_COUNTS",
-    u64,
-    bpf_api::EVENT_COUNT_SLOTS,
-);
-define_map!(MODE_FLAGS, "MODE_FLAGS", u32, bpf_api::MODE_FLAGS_CAPACITY);
-
-#[cfg(target_arch = "bpf")]
-#[map(name = "WORKLOAD_UNITS")]
-static mut WORKLOAD_UNITS: HashMap<u32, u32> =
-    HashMap::with_max_entries(bpf_api::WORKLOAD_UNITS_CAPACITY, 0);
 
 #[cfg(any(test, feature = "fuzzing"))]
-static WORKLOAD_UNITS: TestHashMap<u32, u32, { bpf_api::WORKLOAD_UNITS_CAPACITY as usize }> =
-    TestHashMap::new();
+#[derive(Clone, Copy)]
+pub struct MapDescriptor {
+    pub name: &'static str,
+    pub kind: MapKind,
+    pub capacity: u32,
+    pub clear: fn(),
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+#[derive(Clone, Copy)]
+pub enum MapKind {
+    Array { value_size: u32 },
+    HashMap { key_size: u32, value_size: u32 },
+    RingBuf { byte_size: u32 },
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const EXEC_ALLOWLIST_DESCRIPTOR: ArrayDescriptor<
+    bpf_api::ExecAllowEntry,
+    { bpf_api::EXEC_ALLOWLIST_CAPACITY as usize },
+> = ArrayDescriptor::new("EXEC_ALLOWLIST");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const EXEC_ALLOWLIST_LENGTH_DESCRIPTOR: ArrayDescriptor<u32, 1> =
+    ArrayDescriptor::new("EXEC_ALLOWLIST_LENGTH");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const NET_RULES_DESCRIPTOR: ArrayDescriptor<
+    bpf_api::NetRuleEntry,
+    { bpf_api::NET_RULES_CAPACITY as usize },
+> = ArrayDescriptor::new("NET_RULES");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const NET_RULES_LENGTH_DESCRIPTOR: ArrayDescriptor<u32, 1> =
+    ArrayDescriptor::new("NET_RULES_LENGTH");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const NET_PARENTS_DESCRIPTOR: ArrayDescriptor<
+    bpf_api::NetParentEntry,
+    { bpf_api::NET_PARENTS_CAPACITY as usize },
+> = ArrayDescriptor::new("NET_PARENTS");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const NET_PARENTS_LENGTH_DESCRIPTOR: ArrayDescriptor<u32, 1> =
+    ArrayDescriptor::new("NET_PARENTS_LENGTH");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const FS_RULES_DESCRIPTOR: ArrayDescriptor<
+    bpf_api::FsRuleEntry,
+    { bpf_api::FS_RULES_CAPACITY as usize },
+> = ArrayDescriptor::new("FS_RULES");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const FS_RULES_LENGTH_DESCRIPTOR: ArrayDescriptor<u32, 1> = ArrayDescriptor::new("FS_RULES_LENGTH");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const EVENT_COUNTS_DESCRIPTOR: ArrayDescriptor<u64, { bpf_api::EVENT_COUNT_SLOTS as usize }> =
+    ArrayDescriptor::new("EVENT_COUNTS");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const MODE_FLAGS_DESCRIPTOR: ArrayDescriptor<u32, { bpf_api::MODE_FLAGS_CAPACITY as usize }> =
+    ArrayDescriptor::new("MODE_FLAGS");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const WORKLOAD_UNITS_DESCRIPTOR: HashMapDescriptor<
+    u32,
+    u32,
+    { bpf_api::WORKLOAD_UNITS_CAPACITY as usize },
+> = HashMapDescriptor::new("WORKLOAD_UNITS");
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+const EVENTS_DESCRIPTOR: RingBufDescriptor<{ bpf_api::EVENT_RINGBUF_CAPACITY_BYTES as usize }> =
+    RingBufDescriptor::new("EVENTS");
+
+#[cfg(target_arch = "bpf")]
+type ExecAllowlistMap = Array<bpf_api::ExecAllowEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type ExecAllowlistMap =
+    TestArray<bpf_api::ExecAllowEntry, { bpf_api::EXEC_ALLOWLIST_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type LengthMap = Array<u32>;
+#[cfg(any(test, feature = "fuzzing"))]
+type LengthMap = TestArray<u32, 1>;
+
+#[cfg(target_arch = "bpf")]
+type NetRulesMap = Array<bpf_api::NetRuleEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type NetRulesMap = TestArray<bpf_api::NetRuleEntry, { bpf_api::NET_RULES_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type NetParentsMap = Array<bpf_api::NetParentEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type NetParentsMap = TestArray<bpf_api::NetParentEntry, { bpf_api::NET_PARENTS_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type FsRulesMap = Array<bpf_api::FsRuleEntry>;
+#[cfg(any(test, feature = "fuzzing"))]
+type FsRulesMap = TestArray<bpf_api::FsRuleEntry, { bpf_api::FS_RULES_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type EventCountsMap = Array<u64>;
+#[cfg(any(test, feature = "fuzzing"))]
+type EventCountsMap = TestArray<u64, { bpf_api::EVENT_COUNT_SLOTS as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type ModeFlagsMap = Array<u32>;
+#[cfg(any(test, feature = "fuzzing"))]
+type ModeFlagsMap = TestArray<u32, { bpf_api::MODE_FLAGS_CAPACITY as usize }>;
+
+#[cfg(target_arch = "bpf")]
+type WorkloadUnitsMap = HashMap<u32, u32>;
+#[cfg(any(test, feature = "fuzzing"))]
+type WorkloadUnitsMap = TestHashMap<u32, u32, { bpf_api::WORKLOAD_UNITS_CAPACITY as usize }>;
 
 #[cfg(target_arch = "bpf")]
 type EventsMap = RingBuf;
@@ -391,21 +286,202 @@ type EventsMap = RingBuf;
 type EventsMap = DummyRingBuf;
 
 #[cfg(target_arch = "bpf")]
-const fn events_map() -> EventsMap {
-    RingBuf::with_byte_size(bpf_api::EVENT_RINGBUF_CAPACITY_BYTES, 0)
-}
+#[map(name = "EXEC_ALLOWLIST")]
+static mut EXEC_ALLOWLIST: ExecAllowlistMap = EXEC_ALLOWLIST_DESCRIPTOR.bpf_map();
 
 #[cfg(any(test, feature = "fuzzing"))]
-const fn events_map() -> EventsMap {
-    DummyRingBuf
-}
+static EXEC_ALLOWLIST: ExecAllowlistMap = EXEC_ALLOWLIST_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EXEC_ALLOWLIST_LENGTH")]
+static mut EXEC_ALLOWLIST_LENGTH: LengthMap = EXEC_ALLOWLIST_LENGTH_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EXEC_ALLOWLIST_LENGTH: LengthMap = EXEC_ALLOWLIST_LENGTH_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_RULES")]
+static mut NET_RULES: NetRulesMap = NET_RULES_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_RULES: NetRulesMap = NET_RULES_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_RULES_LENGTH")]
+static mut NET_RULES_LENGTH: LengthMap = NET_RULES_LENGTH_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_RULES_LENGTH: LengthMap = NET_RULES_LENGTH_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_PARENTS")]
+static mut NET_PARENTS: NetParentsMap = NET_PARENTS_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_PARENTS: NetParentsMap = NET_PARENTS_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "NET_PARENTS_LENGTH")]
+static mut NET_PARENTS_LENGTH: LengthMap = NET_PARENTS_LENGTH_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static NET_PARENTS_LENGTH: LengthMap = NET_PARENTS_LENGTH_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "FS_RULES")]
+static mut FS_RULES: FsRulesMap = FS_RULES_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static FS_RULES: FsRulesMap = FS_RULES_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "FS_RULES_LENGTH")]
+static mut FS_RULES_LENGTH: LengthMap = FS_RULES_LENGTH_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static FS_RULES_LENGTH: LengthMap = FS_RULES_LENGTH_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "EVENT_COUNTS")]
+static mut EVENT_COUNTS: EventCountsMap = EVENT_COUNTS_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static EVENT_COUNTS: EventCountsMap = EVENT_COUNTS_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "MODE_FLAGS")]
+static mut MODE_FLAGS: ModeFlagsMap = MODE_FLAGS_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static MODE_FLAGS: ModeFlagsMap = MODE_FLAGS_DESCRIPTOR.host_map();
+
+#[cfg(target_arch = "bpf")]
+#[map(name = "WORKLOAD_UNITS")]
+static mut WORKLOAD_UNITS: WorkloadUnitsMap = WORKLOAD_UNITS_DESCRIPTOR.bpf_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+static WORKLOAD_UNITS: WorkloadUnitsMap = WORKLOAD_UNITS_DESCRIPTOR.host_map();
 
 #[cfg(target_arch = "bpf")]
 #[map(name = "EVENTS")]
-static mut EVENTS: EventsMap = events_map();
+static mut EVENTS: EventsMap = EVENTS_DESCRIPTOR.bpf_map();
 
 #[cfg(any(test, feature = "fuzzing"))]
-static EVENTS: EventsMap = events_map();
+static EVENTS: EventsMap = EVENTS_DESCRIPTOR.host_map();
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_array<T: Copy, const CAPACITY: usize>(map: &'static TestArray<T, CAPACITY>) {
+    map.clear();
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_hash_map<K: Copy + Eq, V: Copy, const CAPACITY: usize>(
+    map: &'static TestHashMap<K, V, CAPACITY>,
+) {
+    map.clear();
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_exec_allowlist() {
+    clear_array(&EXEC_ALLOWLIST);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_exec_allowlist_length() {
+    clear_array(&EXEC_ALLOWLIST_LENGTH);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_net_rules() {
+    clear_array(&NET_RULES);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_net_rules_length() {
+    clear_array(&NET_RULES_LENGTH);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_net_parents() {
+    clear_array(&NET_PARENTS);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_net_parents_length() {
+    clear_array(&NET_PARENTS_LENGTH);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_fs_rules() {
+    clear_array(&FS_RULES);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_fs_rules_length() {
+    clear_array(&FS_RULES_LENGTH);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_event_counts() {
+    clear_array(&EVENT_COUNTS);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_mode_flags() {
+    clear_array(&MODE_FLAGS);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_workload_units_map() {
+    clear_hash_map(&WORKLOAD_UNITS);
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+fn clear_events_map() {
+    EVENTS.clear();
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+const HOST_MAP_DESCRIPTORS: &[MapDescriptor] = &[
+    EXEC_ALLOWLIST_DESCRIPTOR.map_descriptor(clear_exec_allowlist),
+    EXEC_ALLOWLIST_LENGTH_DESCRIPTOR.map_descriptor(clear_exec_allowlist_length),
+    NET_RULES_DESCRIPTOR.map_descriptor(clear_net_rules),
+    NET_RULES_LENGTH_DESCRIPTOR.map_descriptor(clear_net_rules_length),
+    NET_PARENTS_DESCRIPTOR.map_descriptor(clear_net_parents),
+    NET_PARENTS_LENGTH_DESCRIPTOR.map_descriptor(clear_net_parents_length),
+    FS_RULES_DESCRIPTOR.map_descriptor(clear_fs_rules),
+    FS_RULES_LENGTH_DESCRIPTOR.map_descriptor(clear_fs_rules_length),
+    EVENT_COUNTS_DESCRIPTOR.map_descriptor(clear_event_counts),
+    MODE_FLAGS_DESCRIPTOR.map_descriptor(clear_mode_flags),
+    WORKLOAD_UNITS_DESCRIPTOR.map_descriptor(clear_workload_units_map),
+    EVENTS_DESCRIPTOR.map_descriptor(clear_events_map),
+];
+
+#[cfg(any(test, feature = "fuzzing"))]
+pub mod host_maps {
+    pub use super::{MapDescriptor, MapKind};
+
+    pub const MAP_DESCRIPTORS: &[MapDescriptor] = super::HOST_MAP_DESCRIPTORS;
+
+    pub fn reset_all() {
+        for descriptor in MAP_DESCRIPTORS {
+            (descriptor.clear)();
+        }
+    }
+
+    pub fn clear_by_name(name: &str) -> bool {
+        if let Some(descriptor) = MAP_DESCRIPTORS.iter().find(|d| d.name == name) {
+            (descriptor.clear)();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn descriptor(name: &str) -> Option<&'static MapDescriptor> {
+        MAP_DESCRIPTORS.iter().find(|d| d.name == name)
+    }
+}
 
 #[cfg(target_arch = "bpf")]
 unsafe fn load_mode_flags() -> u32 {
@@ -414,7 +490,7 @@ unsafe fn load_mode_flags() -> u32 {
 
 #[cfg(any(test, feature = "fuzzing"))]
 unsafe fn load_mode_flags() -> u32 {
-    MODE_FLAGS.get(0).map(|value| *value).unwrap_or(0)
+    MODE_FLAGS.get(0).unwrap_or(0)
 }
 
 #[cfg(target_arch = "bpf")]
@@ -424,7 +500,7 @@ unsafe fn load_length(map: &LengthMap) -> u32 {
 
 #[cfg(any(test, feature = "fuzzing"))]
 unsafe fn load_length(map: &LengthMap) -> u32 {
-    map.get(0).map(|value| *value).unwrap_or(0)
+    map.get(0).unwrap_or(0)
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
@@ -458,7 +534,7 @@ macro_rules! define_map_accessors {
 
         #[cfg(any(test, feature = "fuzzing"))]
         unsafe fn $load_fn(index: u32) -> Option<$entry> {
-            $map.get(index).map(|entry| *entry)
+            $map.get(index)
         }
 
         #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
@@ -516,7 +592,7 @@ fn increment_event_count() {
 
     #[cfg(any(test, feature = "fuzzing"))]
     {
-        let current = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let current = EVENT_COUNTS.get(0).unwrap_or(0);
         EVENT_COUNTS.set(0, current.wrapping_add(1));
     }
 }
@@ -703,7 +779,7 @@ fn workload_unit_for_pid(pid: u32) -> u32 {
 
 #[cfg(any(test, feature = "fuzzing"))]
 fn workload_unit_for_pid(pid: u32) -> u32 {
-    WORKLOAD_UNITS.get(&pid).map(|value| *value).unwrap_or(0)
+    WORKLOAD_UNITS.get(pid).unwrap_or(0)
 }
 
 #[cfg(target_arch = "bpf")]
@@ -750,12 +826,12 @@ fn set_workload_unit(pid: u32, unit: u32) {
 
 #[cfg(any(test, feature = "fuzzing"))]
 fn remove_workload_unit(pid: u32) {
-    WORKLOAD_UNITS.remove(&pid);
+    WORKLOAD_UNITS.remove(pid);
 }
 
 #[cfg(any(test, feature = "fuzzing"))]
 fn clear_workload_units() {
-    WORKLOAD_UNITS.clear();
+    host_maps::clear_by_name("WORKLOAD_UNITS");
 }
 
 #[cfg(target_arch = "bpf")]
@@ -942,48 +1018,55 @@ fn net_allowed(addr: &[u8; 16], port: u16, protocol: u8) -> bool {
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-fn c_str_len(buf: &[u8; 256]) -> usize {
-    let mut len = 0;
-    while len < buf.len() && buf[len] != 0 {
-        len += 1;
-    }
-    len
+fn c_path(buf: &[u8; 256]) -> Option<&CStr> {
+    CStr::from_bytes_until_nul(buf).ok()
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-fn trimmed_len(buf: &[u8; 256]) -> usize {
-    let mut len = c_str_len(buf);
-    while len > 1 && buf[len - 1] == b'/' {
-        len -= 1;
-    }
-    len
+fn c_str_len(path: &CStr) -> usize {
+    path.to_bytes().len()
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-fn path_prefix_matches(rule_path: &[u8; 256], actual_path: &[u8; 256]) -> bool {
-    let prefix_len = trimmed_len(rule_path);
-    if prefix_len == 0 {
+fn trimmed_len(path: &CStr) -> usize {
+    let bytes = path.to_bytes();
+    if bytes.len() <= 1 {
+        return bytes.len();
+    }
+    bytes
+        .iter()
+        .rposition(|&b| b != b'/')
+        .map(|idx| idx + 1)
+        .unwrap_or(1)
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn trimmed_bytes(path: &CStr) -> &[u8] {
+    let len = trimmed_len(path);
+    &path.to_bytes()[..len]
+}
+
+#[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
+fn path_prefix_matches(rule_path: &CStr, actual_path: &CStr) -> bool {
+    let rule_bytes = trimmed_bytes(rule_path);
+    if rule_bytes.is_empty() {
         return false;
     }
     let path_len = c_str_len(actual_path);
-    if prefix_len > path_len {
+    if rule_bytes.len() > path_len {
         return false;
     }
-    let mut i = 0;
-    while i < prefix_len {
-        if rule_path[i] != actual_path[i] {
-            return false;
-        }
-        i += 1;
+    let actual_bytes = actual_path.to_bytes();
+    if !actual_bytes.starts_with(rule_bytes) {
+        return false;
     }
-    if prefix_len == path_len {
+    if rule_bytes.len() == path_len {
         return true;
     }
-    let last = rule_path[prefix_len - 1];
-    if last == b'/' {
+    if rule_bytes.last().copied() == Some(b'/') {
         return true;
     }
-    actual_path.get(prefix_len).copied() == Some(b'/')
+    actual_bytes.get(rule_bytes.len()).copied() == Some(b'/')
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
@@ -999,12 +1082,18 @@ fn rule_allows_access(rule_access: u8, needed: u8) -> bool {
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-fn fs_entry_allows(entry: &bpf_api::FsRuleEntry, path: &[u8; 256], needed: u8) -> bool {
-    rule_allows_access(entry.rule.access, needed) && path_prefix_matches(&entry.rule.path, path)
+fn fs_entry_allows(entry: &bpf_api::FsRuleEntry, path: &CStr, needed: u8) -> bool {
+    if !rule_allows_access(entry.rule.access, needed) {
+        return false;
+    }
+    let Some(rule_path) = c_path(&entry.rule.path) else {
+        return false;
+    };
+    path_prefix_matches(rule_path, path)
 }
 
 #[cfg(any(target_arch = "bpf", test, feature = "fuzzing"))]
-fn unit_fs_allowed(unit: u32, path: &[u8; 256], needed: u8) -> bool {
+fn unit_fs_allowed(unit: u32, path: &CStr, needed: u8) -> bool {
     let len = fs_rules_len();
     let mut i = 0;
     while i < len {
@@ -1024,6 +1113,9 @@ fn fs_allowed(path: &[u8; 256], needed: u8) -> bool {
     if needed == 0 {
         return true;
     }
+    let Some(path) = c_path(path) else {
+        return false;
+    };
     let mut unit = current_unit();
     let mut checked_root = unit == 0;
     loop {
@@ -1468,6 +1560,7 @@ pub extern "C" fn inode_unlink(_dir: *mut c_void, dentry: *mut c_void) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host_maps;
     use bpf_api::{FS_READ, FS_WRITE};
     use bpf_host::{
         fs::{TestDentry, TestFile},
@@ -1599,7 +1692,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let path = "/var/warden/allowed/file.txt";
         set_fs_rules(&[fs_rule_entry(0, path, FS_READ | FS_WRITE)]);
@@ -1619,7 +1712,7 @@ mod tests {
         assert_eq!(event.verdict, 0);
         assert_eq!(bytes_to_string(&event.path_or_addr), path);
         assert!(bytes_to_string(&event.needed_perm).is_empty());
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 1);
     }
 
@@ -1628,7 +1721,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let rules = default_fs_rules();
         set_fs_rules(&rules);
@@ -1650,9 +1743,9 @@ mod tests {
         assert_eq!(allowed_event.verdict, 0);
         assert_eq!(bytes_to_string(&allowed_event.path_or_addr), allowed_path);
         assert!(bytes_to_string(&allowed_event.needed_perm).is_empty());
-        let allowed_count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let allowed_count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(allowed_count, 1);
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let path = "/etc/warden/forbidden.txt";
         let path_bytes = c_string(path);
@@ -1676,7 +1769,7 @@ mod tests {
         reset_fs_state();
         enable_observe_mode();
         assert!(is_observe_mode(), "observe mode should be enabled");
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let path = "/var/warden/forbidden.txt";
         let path_bytes = c_string(path);
@@ -1691,7 +1784,7 @@ mod tests {
         assert_eq!(event.verdict, 1);
         assert_eq!(bytes_to_string(&event.path_or_addr), path);
         assert_eq!(bytes_to_string(&event.needed_perm), "allow.fs.read_extra");
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 1);
     }
 
@@ -1754,7 +1847,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let rules = default_fs_rules();
         set_fs_rules(&rules);
@@ -1770,7 +1863,7 @@ mod tests {
         assert_eq!(event.action, ACTION_OPEN);
         assert_eq!(event.verdict, 0);
         assert_eq!(bytes_to_string(&event.path_or_addr), path);
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 1);
     }
 
@@ -1779,7 +1872,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let mut file = TestFile {
             path: ptr::null(),
@@ -1788,7 +1881,7 @@ mod tests {
         let result = file_open((&mut file) as *mut _ as *mut c_void, ptr::null_mut());
         assert_ne!(result, 0);
         assert!(LAST_EVENT.lock().unwrap().is_none());
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 0);
     }
 
@@ -1894,6 +1987,31 @@ mod tests {
     }
 
     #[test]
+    fn file_permission_allows_rule_with_trailing_slash() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
+        reset_fs_state();
+        set_fs_rules(&[fs_rule_entry(0, "/var/data/", FS_READ | FS_WRITE)]);
+
+        let file_path = c_string("/var/data/report.log");
+        let mut file = TestFile {
+            path: file_path.as_ptr(),
+            mode: FMODE_READ | FMODE_WRITE,
+        };
+        let file_ptr = (&mut file) as *mut _ as *mut c_void;
+        assert_eq!(file_permission(file_ptr, MAY_READ), 0);
+        assert_eq!(file_permission(file_ptr, MAY_WRITE), 0);
+
+        let dir_path = c_string("/var/data/");
+        let mut dir = TestFile {
+            path: dir_path.as_ptr(),
+            mode: FMODE_READ,
+        };
+        let dir_ptr = (&mut dir) as *mut _ as *mut c_void;
+        assert_eq!(file_permission(dir_ptr, MAY_READ), 0);
+    }
+
+    #[test]
     fn file_permission_denies_mismatched_prefix() {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
@@ -1910,11 +2028,26 @@ mod tests {
     }
 
     #[test]
+    fn file_permission_denies_trailing_slash_rule_without_separator() {
+        let _g = TEST_LOCK.lock().unwrap();
+        reset_network_state();
+        reset_fs_state();
+        set_fs_rules(&[fs_rule_entry(0, "/var/data/", FS_READ)]);
+        let file_path = c_string("/var/data-archive");
+        let mut file = TestFile {
+            path: file_path.as_ptr(),
+            mode: FMODE_READ,
+        };
+        let file_ptr = (&mut file) as *mut _ as *mut c_void;
+        assert_ne!(file_permission(file_ptr, MAY_READ), 0);
+    }
+
+    #[test]
     fn inode_rename_denies_when_source_not_allowed() {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let old_path = "/etc/warden/src.txt";
         let new_path = "/etc/warden/dst.txt";
@@ -1940,7 +2073,7 @@ mod tests {
         assert_eq!(event.verdict, 1);
         assert_eq!(bytes_to_string(&event.path_or_addr), old_path);
         assert_eq!(bytes_to_string(&event.needed_perm), "allow.fs.write_extra");
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 1);
     }
 
@@ -1949,7 +2082,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let old_path = "/etc/warden/allowed.txt";
         let new_path = "/etc/warden/blocked.txt";
@@ -1975,7 +2108,7 @@ mod tests {
         assert_eq!(event.verdict, 1);
         assert_eq!(bytes_to_string(&event.path_or_addr), new_path);
         assert_eq!(bytes_to_string(&event.needed_perm), "allow.fs.write_extra");
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 1);
     }
 
@@ -1984,7 +2117,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let old_path = "/workspace/dir/source.txt";
         let new_path = "/workspace/dir/dest.txt";
@@ -2006,7 +2139,7 @@ mod tests {
         );
         assert_eq!(result, 0);
         assert!(LAST_EVENT.lock().unwrap().is_none());
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 0);
     }
 
@@ -2017,7 +2150,7 @@ mod tests {
         reset_fs_state();
         enable_observe_mode();
         assert!(is_observe_mode(), "observe mode should be enabled");
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let old_path = "/etc/warden/src.txt";
         let new_path = "/etc/warden/dst.txt";
@@ -2041,7 +2174,7 @@ mod tests {
         assert_eq!(event.action, ACTION_RENAME);
         assert_eq!(event.verdict, 1);
         assert_eq!(bytes_to_string(&event.path_or_addr), new_path);
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 2);
     }
 
@@ -2050,7 +2183,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let old_path = "/etc/warden/src.txt";
         let new_path = "/etc/warden/dst.txt";
@@ -2074,7 +2207,7 @@ mod tests {
         assert_eq!(event.action, ACTION_RENAME);
         assert_eq!(event.verdict, 1);
         assert_eq!(bytes_to_string(&event.path_or_addr), new_path);
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 2);
     }
 
@@ -2083,7 +2216,7 @@ mod tests {
         let _g = TEST_LOCK.lock().unwrap();
         reset_network_state();
         reset_fs_state();
-        EVENT_COUNTS.clear();
+        host_maps::clear_by_name("EVENT_COUNTS");
         LAST_EVENT.lock().unwrap().take();
         let mut old_dentry = TestDentry { name: ptr::null() };
         let mut new_dentry = TestDentry { name: ptr::null() };
@@ -2096,7 +2229,7 @@ mod tests {
         );
         assert_ne!(result, 0);
         assert!(LAST_EVENT.lock().unwrap().is_none());
-        let count = EVENT_COUNTS.get(0).map(|value| *value).unwrap_or(0);
+        let count = EVENT_COUNTS.get(0).unwrap_or(0);
         assert_eq!(count, 0);
     }
 
@@ -2301,8 +2434,8 @@ mod tests {
     }
 
     fn set_net_rules(entries: &[bpf_api::NetRuleEntry]) {
-        NET_RULES.clear();
-        NET_RULES_LENGTH.clear();
+        host_maps::clear_by_name("NET_RULES");
+        host_maps::clear_by_name("NET_RULES_LENGTH");
         for (idx, entry) in entries.iter().enumerate() {
             NET_RULES.set(idx as u32, *entry);
         }
@@ -2310,8 +2443,8 @@ mod tests {
     }
 
     fn set_net_parents(entries: &[bpf_api::NetParentEntry]) {
-        NET_PARENTS.clear();
-        NET_PARENTS_LENGTH.clear();
+        host_maps::clear_by_name("NET_PARENTS");
+        host_maps::clear_by_name("NET_PARENTS_LENGTH");
         for (idx, entry) in entries.iter().enumerate() {
             NET_PARENTS.set(idx as u32, *entry);
         }
@@ -2319,23 +2452,23 @@ mod tests {
     }
 
     fn reset_mode_flags() {
-        MODE_FLAGS.clear();
+        host_maps::clear_by_name("MODE_FLAGS");
         MODE_FLAGS.set(0, bpf_api::MODE_FLAG_ENFORCE);
     }
 
     fn reset_network_state() {
-        NET_RULES.clear();
-        NET_RULES_LENGTH.clear();
-        NET_PARENTS.clear();
-        NET_PARENTS_LENGTH.clear();
+        host_maps::clear_by_name("NET_RULES");
+        host_maps::clear_by_name("NET_RULES_LENGTH");
+        host_maps::clear_by_name("NET_PARENTS");
+        host_maps::clear_by_name("NET_PARENTS_LENGTH");
         reset_mode_flags();
         clear_workload_units();
         refresh_current_unit();
     }
 
     fn set_fs_rules(entries: &[bpf_api::FsRuleEntry]) {
-        FS_RULES.clear();
-        FS_RULES_LENGTH.clear();
+        host_maps::clear_by_name("FS_RULES");
+        host_maps::clear_by_name("FS_RULES_LENGTH");
         for (idx, entry) in entries.iter().enumerate() {
             FS_RULES.set(idx as u32, *entry);
         }
@@ -2343,8 +2476,8 @@ mod tests {
     }
 
     fn reset_fs_state() {
-        FS_RULES.clear();
-        FS_RULES_LENGTH.clear();
+        host_maps::clear_by_name("FS_RULES");
+        host_maps::clear_by_name("FS_RULES_LENGTH");
         reset_mode_flags();
         clear_workload_units();
         refresh_current_unit();
@@ -2356,8 +2489,8 @@ mod tests {
     }
 
     fn reset_exec_state() {
-        EXEC_ALLOWLIST.clear();
-        EXEC_ALLOWLIST_LENGTH.clear();
+        host_maps::clear_by_name("EXEC_ALLOWLIST");
+        host_maps::clear_by_name("EXEC_ALLOWLIST_LENGTH");
     }
 
     fn fs_rule_entry(unit: u32, path: &str, access: u8) -> bpf_api::FsRuleEntry {

--- a/crates/bpf-host/Cargo.toml
+++ b/crates/bpf-host/Cargo.toml
@@ -10,3 +10,4 @@ documentation = "https://docs.rs/qqrm-bpf-host"
 readme = "../../README.md"
 
 [dependencies]
+heapless = "0.8"

--- a/crates/bpf-host/Cargo.toml
+++ b/crates/bpf-host/Cargo.toml
@@ -11,3 +11,4 @@ readme = "../../README.md"
 
 [dependencies]
 heapless = "0.8"
+spin = "0.9"


### PR DESCRIPTION
## Summary
- add the `heapless` dependency for the bpf-host crate
- reimplement the TestArray and TestHashMap host shims with heapless::LinearMap and RefCell-based borrowing
- update host-only map consumers in bpf-core to operate on reference-based accessors

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable; falls back to emulation and hangs, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68da446a54108332b0937467b5d5722c