### PR TITLE
Document direct invocation requirements for relocated helper scripts

### DIFF
--- a/scripts/examples/run_examples.sh
+++ b/scripts/examples/run_examples.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# NOTE: This helper is executed directly via ./scripts/examples/run_examples.sh.
+# Keep the executable bit set so CI and documentation flows continue to work.
+
 declare -A EXAMPLE_DIRS=(
     [network-build]="network-build"
     [spawn-bash]="spawn-bash"

--- a/scripts/setup/repo-setup.sh
+++ b/scripts/setup/repo-setup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# NOTE: This helper runs via ./scripts/setup/repo-setup.sh throughout the docs and checks.
+# Preserve its executable bit so it can be invoked without explicitly calling bash.
+
 REMOTE_NAME="${REMOTE_NAME:-origin}"
 FETCH_URL="${REMOTE_FETCH_URL:-}"
 PUSH_URL="${REMOTE_PUSH_URL:-}"


### PR DESCRIPTION
## Summary
- add inline documentation reminding maintainers that scripts/examples/run_examples.sh is invoked directly and must remain executable
- add matching guidance in scripts/setup/repo-setup.sh so its execute bit stays set for docs and CI flows

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- ./scripts/examples/run_examples.sh
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: local environment lacks Docker; emulation mode hangs before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68dae073be7083329cbb18604fb766b6