### PR TITLE
Remove cargo-deny tooling from CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,9 +33,6 @@ jobs:
           tool: cargo-audit
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-deny
-      - uses: taiki-e/install-action@v2
-        with:
           tool: cargo-udeps
       - uses: taiki-e/install-action@v2
         with:
@@ -64,10 +61,6 @@ jobs:
         id: cargo_audit
         run: cargo audit
         continue-on-error: true
-      - name: cargo deny check --disable-fetch
-        id: cargo_deny
-        run: ./scripts/ci/run_cargo_deny.sh
-        continue-on-error: true
       - uses: dtolnay/rust-toolchain@nightly
       - name: cargo +nightly udeps --all-targets --all-features
         id: cargo_udeps
@@ -82,7 +75,6 @@ jobs:
           CARGO_NEXTEST_OUTCOME: ${{ steps.cargo_nextest.outcome }}
           CARGO_MACHETE_OUTCOME: ${{ steps.cargo_machete.outcome }}
           CARGO_AUDIT_OUTCOME: ${{ steps.cargo_audit.outcome }}
-          CARGO_DENY_OUTCOME: ${{ steps.cargo_deny.outcome }}
           CARGO_UDEPS_OUTCOME: ${{ steps.cargo_udeps.outcome }}
         run: ./scripts/ci/aggregate_cargo_checks.sh
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ you to refine rules before enabling blocking.
 Use `scripts/run_ci_checks.sh` to reproduce the pull request GitHub Actions checks locally. The script:
 
 - installs missing Debian packages (`pkg-config`, `libseccomp-dev`, `protobuf-compiler`, `jq`, `xxhash`),
-- installs the cargo subcommands required by the pipeline (`cargo-machete`, `cargo-audit`, `cargo-deny`, `cargo-nextest`, `cargo-udeps`, `cargo-fuzz`),
+- installs the cargo subcommands required by the pipeline (`cargo-machete`, `cargo-audit`, `cargo-nextest`, `cargo-udeps`, `cargo-fuzz`),
 - ensures the stable toolchain has the `rustfmt`, `clippy`, and `llvm-tools-preview` components, plus a nightly toolchain for `cargo udeps` and `cargo fuzz`,
 - runs the same validation commands as the CI jobs, including formatting, linting, tests, supply-chain checks, example runs, and fuzz builds.
 

--- a/scripts/ci/aggregate_cargo_checks.sh
+++ b/scripts/ci/aggregate_cargo_checks.sh
@@ -18,7 +18,6 @@ record_outcome "${CARGO_CLIPPY_OUTCOME}" "cargo clippy --all-targets --all-featu
 record_outcome "${CARGO_NEXTEST_OUTCOME}" "cargo nextest run"
 record_outcome "${CARGO_MACHETE_OUTCOME}" "cargo machete"
 record_outcome "${CARGO_AUDIT_OUTCOME}" "cargo audit"
-record_outcome "${CARGO_DENY_OUTCOME}" "cargo deny check --disable-fetch"
 record_outcome "${CARGO_UDEPS_OUTCOME}" "cargo +nightly udeps --all-targets --all-features"
 
 if [[ -s "$failures_file" ]]; then

--- a/scripts/ci/run_cargo_deny.sh
+++ b/scripts/ci/run_cargo_deny.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cargo deny fetch
-cargo deny check --disable-fetch

--- a/scripts/run_ci_checks.sh
+++ b/scripts/run_ci_checks.sh
@@ -117,7 +117,6 @@ main() {
   log_step "Ensuring cargo subcommands"
   ensure_cargo_tool "${install_tools}" cargo-machete cargo-machete
   ensure_cargo_tool "${install_tools}" cargo-audit cargo-audit
-  ensure_cargo_tool "${install_tools}" cargo-deny cargo-deny
   ensure_cargo_tool "${install_tools}" cargo-nextest cargo-nextest
   ensure_cargo_tool "${install_tools}" cargo-udeps cargo-udeps
   ensure_cargo_tool "${install_tools}" cargo-fuzz cargo-fuzz
@@ -158,12 +157,6 @@ main() {
 
   log_step "Running cargo audit"
   cargo audit
-
-  log_step "Running cargo deny fetch"
-  cargo deny fetch
-
-  log_step "Running cargo deny check --disable-fetch"
-  cargo deny check --disable-fetch
 
   log_step "Running cargo +nightly udeps --all-targets --all-features"
   cargo +nightly udeps --all-targets --all-features


### PR DESCRIPTION
## Summary
- drop cargo-deny installation and check steps from the CI workflow
- simplify the CI aggregation helper and local parity script to match the removed tool
- update documentation to reflect the slimmer toolchain and remove the dedicated cargo-deny runner script

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- wrkflw validate
- wrkflw run .github/workflows/CI.yml *(fails: Docker unavailable; aborted after falling back to emulation)*

------
https://chatgpt.com/codex/tasks/task_e_68dc47d6831c833297218ca558650419