### PR TITLE
Restore manual bpf API definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,9 +1706,6 @@ dependencies = [
 [[package]]
 name = "qqrm-bpf-api"
 version = "0.1.0"
-dependencies = [
- "static_assertions",
-]
 
 [[package]]
 name = "qqrm-bpf-core"
@@ -2240,12 +2237,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/bpf-api/Cargo.toml
+++ b/crates/bpf-api/Cargo.toml
@@ -13,5 +13,3 @@ readme = "../../README.md"
 path = "src/lib.rs"
 crate-type = ["lib"]
 
-[dependencies]
-static_assertions = "1.1"

--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use static_assertions::const_assert_eq;
-
 /// Bit flag for read access.
 pub const FS_READ: u8 = 1;
 /// Bit flag for write access.
@@ -110,10 +108,10 @@ pub struct Event {
     pub needed_perm: [u8; 64],
 }
 
-const_assert_eq!(core::mem::size_of::<ExecAllowEntry>(), 256);
-const_assert_eq!(core::mem::size_of::<NetRule>(), 20);
-const_assert_eq!(core::mem::size_of::<NetRuleEntry>(), 24);
-const_assert_eq!(core::mem::size_of::<NetParentEntry>(), 8);
-const_assert_eq!(core::mem::size_of::<FsRule>(), 260);
-const_assert_eq!(core::mem::size_of::<FsRuleEntry>(), 264);
-const_assert_eq!(core::mem::size_of::<Event>(), 360);
+const _: [(); 256] = [(); core::mem::size_of::<ExecAllowEntry>()];
+const _: [(); 20] = [(); core::mem::size_of::<NetRule>()];
+const _: [(); 24] = [(); core::mem::size_of::<NetRuleEntry>()];
+const _: [(); 8] = [(); core::mem::size_of::<NetParentEntry>()];
+const _: [(); 260] = [(); core::mem::size_of::<FsRule>()];
+const _: [(); 264] = [(); core::mem::size_of::<FsRuleEntry>()];
+const _: [(); 360] = [(); core::mem::size_of::<Event>()];


### PR DESCRIPTION
## Summary
- restore the hand-written constants and structs in `qqrm-bpf-api` instead of including generated code
- drop the JSON schema, build script, and related dependencies from the crate configuration
- keep ABI checks with const array assertions so the crate stays lightweight

## Testing
- cargo fmt --all
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete

------
https://chatgpt.com/codex/tasks/task_e_68dc5f49dd6883328f4f2ad76d5cca0f