### PR TITLE
Align BPF core maps with runtime usage

### DIFF
--- a/crates/bpf-api/src/lib.rs
+++ b/crates/bpf-api/src/lib.rs
@@ -15,8 +15,6 @@ pub const NET_PARENTS_CAPACITY: u32 = 256;
 pub const FS_RULES_CAPACITY: u32 = 256;
 /// Size of the event ring buffer in bytes.
 pub const EVENT_RINGBUF_CAPACITY_BYTES: u32 = 4096;
-/// Number of slots tracked for emitted event counters.
-pub const EVENT_COUNT_SLOTS: u32 = 1;
 /// Number of entries in the mode flags map.
 pub const MODE_FLAGS_CAPACITY: u32 = 1;
 /// Maximum number of workload-to-unit mappings supported by the eBPF map.


### PR DESCRIPTION
## Summary
- remove the unused EVENT_COUNTS map from qqrm-bpf-core and the matching constant from qqrm-bpf-api so the layout matches the runtime
- switch the host-side test harness to record emitted events directly and assert counts from the ring buffer helpers
- consolidate duplicated host/BPF map accessors for workload units and mode flags without breaking fuzzing/test builds

## Testing
- cargo fmt
- cargo check --tests --benches
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo machete
- ./scripts/check_path_versions.sh
- wrkflw validate

------
https://chatgpt.com/codex/tasks/task_e_68dc7884f920833286f981b30455e41f