### PR TITLE
Add doctor/setup and init-from-events first-run workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ the cargo-warden binaries themselves.
    reuse the copy from a release package) and place it under
    `${XDG_DATA_HOME:-$HOME/.local/share}/cargo-warden/bpf`.
 
+   Alternatively, install the bundle into the correct location with:
+
+   ```bash
+   cargo warden setup --bundle prebuilt.tar.gz
+   ```
+
+   If you're unsure what's missing on the host/container, run:
+
+   ```bash
+   cargo warden doctor
+   ```
+
 2. Run any command in observe mode with the built-in starter policy (no
    `warden.toml` required):
 
@@ -65,6 +77,12 @@ the cargo-warden binaries themselves.
 
    ```bash
    cargo warden init
+   ```
+
+   To generate a starter policy from the most recent denied events:
+
+   ```bash
+   cargo warden init --from-last-run --policy-mode enforce
    ```
 
    Edit the generated `warden.toml` to promote specific permissions to enforce
@@ -169,6 +187,8 @@ enabled; avoid `--privileged` runners.
 | `cargo warden init` | Creates a default `warden.toml` policy file. |
 | `cargo warden status` | Shows the effective policy, sandbox mode, and recent events. |
 | `cargo warden report --format <text\|json\|sarif>` | Writes the latest audit events in the selected format. |
+| `cargo warden doctor` | Checks kernel/LSM/cgroup prerequisites, bundle installation, and privilege isolation. |
+| `cargo warden setup --bundle <prebuilt.tar.gz>` | Installs the prebuilt eBPF bundle into the default search path. |
 
 Global flags apply to every subcommand:
 

--- a/crates/bpf-host/src/prebuilt.rs
+++ b/crates/bpf-host/src/prebuilt.rs
@@ -204,6 +204,20 @@ impl PrebuiltObject {
     }
 }
 
+/// Returns the default installation directory under XDG data home.
+///
+/// This matches the search path used by [`PrebuiltObject::locate_default`].
+pub fn default_install_dir() -> Option<PathBuf> {
+    data_home().map(|home| home.join(XDG_SUBDIR))
+}
+
+/// Returns the full list of directories searched by [`PrebuiltObject::locate_default`].
+///
+/// Useful for diagnostics and setup tooling.
+pub fn default_search_directories() -> Vec<PathBuf> {
+    candidate_directories()
+}
+
 fn candidate_directories() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,12 +23,15 @@ event-reporting = { version = "0.1.0", path = "../event-reporting" }
 itertools = "0.12"
 warden-policy-orchestrator = { version = "0.1.0", path = "../policy-orchestrator" }
 libc = "0.2"
+flate2 = "1"
+tar = "0.4"
+tempfile = "3"
+bpf-host = { package = "warden-bpf-host", version = "0.1.0", path = "../bpf-host" }
 
 
 [dev-dependencies]
 serial_test = "3"
 assert_cmd = "2"
-tempfile = "3"
 bpf-api = { package = "warden-bpf-api", version = "0.1.0", path = "../bpf-api" }
 warden-testkits = { package = "warden-testkits", version = "0.1.0", path = "../testkits" }
 

--- a/crates/cli/src/commands/doctor.rs
+++ b/crates/cli/src/commands/doctor.rs
@@ -1,0 +1,193 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use bpf_host::prebuilt::{PrebuiltObject, default_search_directories};
+
+use crate::privileges;
+
+const MIN_KERNEL_MAJOR: u64 = 5;
+const MIN_KERNEL_MINOR: u64 = 13;
+
+pub(crate) fn exec() -> io::Result<()> {
+    println!("cargo-warden doctor");
+
+    check_kernel()?;
+    check_bpf_lsm()?;
+    check_cgroup_v2()?;
+    check_prebuilt()?;
+    check_privileges()?;
+
+    Ok(())
+}
+
+fn check_kernel() -> io::Result<()> {
+    let release = fs::read_to_string("/proc/sys/kernel/osrelease")
+        .unwrap_or_else(|_| String::new())
+        .trim()
+        .to_string();
+
+    let parsed = parse_kernel_release(&release);
+
+    match parsed {
+        Some((major, minor))
+            if (major > MIN_KERNEL_MAJOR)
+                || (major == MIN_KERNEL_MAJOR && minor >= MIN_KERNEL_MINOR) =>
+        {
+            println!("kernel: OK ({release})");
+        }
+        Some((major, minor)) => {
+            println!(
+                "kernel: FAIL ({release}); need >= {MIN_KERNEL_MAJOR}.{MIN_KERNEL_MINOR} (found {major}.{minor})"
+            );
+        }
+        None if !release.is_empty() => {
+            println!("kernel: WARN ({release}); could not parse, expected leading MAJOR.MINOR");
+        }
+        None => {
+            println!("kernel: WARN (unknown); could not read /proc/sys/kernel/osrelease");
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_kernel_release(release: &str) -> Option<(u64, u64)> {
+    let mut split = release.split(|c: char| !c.is_ascii_digit() && c != '.');
+    let first = split.next()?;
+    let mut nums = first.split('.');
+    let major = nums.next()?.parse().ok()?;
+    let minor = nums.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+fn check_bpf_lsm() -> io::Result<()> {
+    let path = Path::new("/sys/kernel/security/lsm");
+    match fs::read_to_string(path) {
+        Ok(contents) => {
+            let has = contents
+                .split(|c: char| c.is_ascii_whitespace() || c == ',')
+                .any(|part| part.trim() == "bpf");
+            if has {
+                println!("bpf_lsm: OK");
+            } else {
+                println!("bpf_lsm: FAIL (bpf not present in /sys/kernel/security/lsm)");
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            println!("bpf_lsm: WARN (/sys/kernel/security/lsm not found)");
+        }
+        Err(err) => {
+            println!("bpf_lsm: WARN (failed to read /sys/kernel/security/lsm: {err})");
+        }
+    }
+    Ok(())
+}
+
+fn check_cgroup_v2() -> io::Result<()> {
+    let controllers = Path::new("/sys/fs/cgroup/cgroup.controllers");
+    if controllers.exists() {
+        println!("cgroup_v2: OK");
+    } else {
+        println!("cgroup_v2: FAIL (/sys/fs/cgroup/cgroup.controllers missing; need cgroup v2)");
+    }
+    Ok(())
+}
+
+fn check_prebuilt() -> io::Result<()> {
+    match PrebuiltObject::locate_default() {
+        Ok(obj) => {
+            let path = obj.path();
+            let mut extra = Vec::new();
+            if let Some(min) = obj.kernel_min() {
+                extra.push(format!("kernel_min={min}"));
+            }
+            if let Some(ts) = obj.generated_at() {
+                extra.push(format!("generated_at={ts}"));
+            }
+            let extra = if extra.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", extra.join(", "))
+            };
+            println!(
+                "bpf_prebuilt: OK (version={} path={}){extra}",
+                obj.version(),
+                path.display(),
+            );
+        }
+        Err(err) => {
+            println!("bpf_prebuilt: FAIL ({err})");
+            let dirs = default_search_directories();
+            if !dirs.is_empty() {
+                println!("bpf_prebuilt: searched:");
+                for dir in dirs {
+                    println!("  - {}", dir.display());
+                }
+                println!(
+                    "bpf_prebuilt: next: download prebuilt.tar.gz and run `cargo warden setup --bundle prebuilt.tar.gz`"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_privileges() -> io::Result<()> {
+    if privileges::is_privilege_check_skipped() {
+        println!("privileges: WARN (CARGO_WARDEN_SKIP_PRIVILEGE_CHECK set; enforcement disabled)");
+        return Ok(());
+    }
+
+    match privileges::is_isolated() {
+        Ok(true) => println!("isolation: OK (container/VM markers detected)"),
+        Ok(false) => {
+            println!("isolation: FAIL (no container/VM markers detected)");
+            println!(
+                "isolation: next: run inside a dedicated container/VM with its own network namespace"
+            );
+        }
+        Err(err) => println!("isolation: WARN ({err})"),
+    }
+
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 {
+        println!("euid: FAIL (running as root; cargo-warden rejects root)");
+    } else {
+        println!("euid: OK ({euid})");
+    }
+
+    match privileges::effective_capabilities() {
+        Ok(caps) => {
+            let required = privileges::required_cap_mask();
+            let allowed = privileges::allowed_cap_mask();
+            let missing = required & !caps;
+            let extra = caps & !allowed;
+
+            if missing != 0 {
+                println!(
+                    "caps: FAIL (missing: {}; effective: {})",
+                    privileges::describe_cap_mask(missing),
+                    privileges::describe_cap_mask(caps)
+                );
+            } else if extra != 0 {
+                println!(
+                    "caps: FAIL (extra: {}; effective: {})",
+                    privileges::describe_cap_mask(extra),
+                    privileges::describe_cap_mask(caps)
+                );
+            } else {
+                println!(
+                    "caps: OK (effective: {}; allowed: {})",
+                    privileges::describe_cap_mask(caps),
+                    privileges::describe_cap_mask(allowed)
+                );
+            }
+        }
+        Err(err) => {
+            println!("caps: WARN ({err})");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -1,5 +1,10 @@
+use std::collections::BTreeMap;
 use std::io::{self, BufRead, Write};
 use std::path::Path;
+
+use event_reporting::EventRecord;
+use policy_core::Mode;
+use serde_jsonlines::JsonLinesReader;
 
 pub(crate) fn exec() -> io::Result<()> {
     let mut input = io::stdin().lock();
@@ -8,11 +13,24 @@ pub(crate) fn exec() -> io::Result<()> {
 }
 
 pub(crate) fn exec_with<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> io::Result<()> {
-    let path = Path::new("warden.toml");
+    exec_with_path(input, output, Path::new("warden.toml"))
+}
+
+pub(crate) fn exec_to(output_path: &Path) -> io::Result<()> {
+    let mut input = io::stdin().lock();
+    let mut output = io::stdout();
+    exec_with_path(&mut input, &mut output, output_path)
+}
+
+fn exec_with_path<R: BufRead, W: Write>(
+    input: &mut R,
+    output: &mut W,
+    path: &Path,
+) -> io::Result<()> {
     if path.exists() {
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
-            "warden.toml already exists",
+            format!("{} already exists", path.display()),
         ));
     }
     writeln!(
@@ -48,6 +66,179 @@ pub(crate) fn exec_with<R: BufRead, W: Write>(input: &mut R, output: &mut W) -> 
     );
     std::fs::write(path, content)?;
     Ok(())
+}
+
+pub(crate) fn exec_from_events(
+    events_path: &Path,
+    output_path: &Path,
+    mode: Mode,
+) -> io::Result<()> {
+    if output_path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("{} already exists", output_path.display()),
+        ));
+    }
+
+    let summary = collect_policy_hints(events_path)?;
+    let content = render_generated_policy(&summary, mode);
+    std::fs::write(output_path, content)?;
+
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct PolicyHintSummary {
+    allow: BTreeMap<&'static str, Vec<String>>,
+    unknown: Vec<(String, String)>,
+    skipped: usize,
+}
+
+fn collect_policy_hints(events_path: &Path) -> io::Result<PolicyHintSummary> {
+    let mut summary = PolicyHintSummary::default();
+
+    let file = std::fs::File::open(events_path)?;
+    let reader = io::BufReader::new(file);
+
+    for record in JsonLinesReader::new(reader).read_all::<EventRecord>() {
+        match record {
+            Ok(event) => {
+                if event.verdict != 1 {
+                    continue;
+                }
+                if event.needed_perm.is_empty() {
+                    continue;
+                }
+                match event.needed_perm.as_str() {
+                    "allow.exec.allowed" => {
+                        push_value(&mut summary.allow, "allow.exec", &event.path_or_addr)
+                    }
+                    "allow.net.hosts" => {
+                        push_value(&mut summary.allow, "allow.net", &event.path_or_addr)
+                    }
+                    "allow.fs.write_extra" => push_value(
+                        &mut summary.allow,
+                        "allow.fs.write_extra",
+                        &event.path_or_addr,
+                    ),
+                    "allow.fs.read_extra" => push_value(
+                        &mut summary.allow,
+                        "allow.fs.read_extra",
+                        &event.path_or_addr,
+                    ),
+                    "allow.env.read" => {
+                        push_value(&mut summary.allow, "allow.env", &event.path_or_addr)
+                    }
+                    "syscall.deny" => {
+                        push_value(&mut summary.allow, "syscall.deny", &event.path_or_addr)
+                    }
+                    other => summary
+                        .unknown
+                        .push((other.to_string(), event.path_or_addr)),
+                }
+            }
+            Err(err) if is_deserialization_error(&err) => summary.skipped += 1,
+            Err(err) => return Err(err),
+        }
+    }
+
+    for values in summary.allow.values_mut() {
+        values.sort();
+        values.dedup();
+    }
+    summary.unknown.sort();
+    summary.unknown.dedup();
+
+    Ok(summary)
+}
+
+fn is_deserialization_error(err: &io::Error) -> bool {
+    err.kind() == io::ErrorKind::InvalidData
+        && err
+            .get_ref()
+            .and_then(|inner| inner.downcast_ref::<serde_json::Error>())
+            .is_some()
+}
+
+fn push_value(map: &mut BTreeMap<&'static str, Vec<String>>, key: &'static str, value: &str) {
+    map.entry(key).or_default().push(value.to_string());
+}
+
+fn render_generated_policy(summary: &PolicyHintSummary, mode: Mode) -> String {
+    let mode_str = match mode {
+        Mode::Observe => "observe",
+        Mode::Enforce => "enforce",
+    };
+
+    let exec_allowed = toml_array(summary.allow.get("allow.exec").cloned().unwrap_or_default());
+    let net_hosts = toml_array(summary.allow.get("allow.net").cloned().unwrap_or_default());
+    let fs_write = toml_array(
+        summary
+            .allow
+            .get("allow.fs.write_extra")
+            .cloned()
+            .unwrap_or_default(),
+    );
+    let fs_read = toml_array(
+        summary
+            .allow
+            .get("allow.fs.read_extra")
+            .cloned()
+            .unwrap_or_default(),
+    );
+
+    let mut content = format!(
+        "# Generated from denied events in warden-events.jsonl\n\
+# Review and tighten before using in production CI.\n\
+mode = \"{}\"\n\
+fs.default = \"strict\"\n\
+net.default = \"deny\"\n\
+exec.default = \"allowlist\"\n\
+\n\
+[allow.exec]\n\
+allowed = {}\n\
+\n\
+[allow.net]\n\
+hosts = {}\n\
+\n\
+[allow.fs]\n\
+# Strict mode implicitly allows writing to the Cargo target directory (including OUT_DIR).\n\
+write_extra = {}\n\
+# Strict mode implicitly allows reading from the workspace root.\n\
+read_extra = {}\n",
+        mode_str, exec_allowed, net_hosts, fs_write, fs_read
+    );
+
+    if let Some(env) = summary.allow.get("allow.env") {
+        let env_read = toml_array(env.clone());
+        content.push_str("\n[allow.env]\n");
+        content.push_str(&format!("read = {}\n", env_read));
+    }
+
+    if let Some(syscalls) = summary.allow.get("syscall.deny") {
+        let deny = toml_array(syscalls.clone());
+        content.push_str("\n[syscall]\n");
+        content.push_str(&format!("deny = {}\n", deny));
+    }
+
+    if summary.skipped > 0 {
+        content.push_str(&format!(
+            "\n# Note: skipped {} malformed event records while generating.\n",
+            summary.skipped
+        ));
+    }
+    if !summary.unknown.is_empty() {
+        content.push_str("\n# Unhandled policy hints (needed_perm => value):\n");
+        for (perm, value) in &summary.unknown {
+            content.push_str(&format!("# - {perm} => {value}\n"));
+        }
+    }
+
+    content
+}
+
+fn toml_array(values: Vec<String>) -> toml::Value {
+    toml::Value::Array(values.into_iter().map(toml::Value::String).collect())
 }
 
 #[cfg(test)]
@@ -129,5 +320,35 @@ mod tests {
         let mut output = Vec::new();
         let err = exec_with(&mut input, &mut output).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+    }
+
+    #[test]
+    #[serial]
+    fn exec_from_events_generates_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let _guard = crate::test_support::DirGuard::change_to(dir.path());
+
+        let events_path = dir.path().join("warden-events.jsonl");
+        std::fs::write(
+            &events_path,
+            "{\"pid\":1,\"tgid\":1,\"time_ns\":0,\"unit\":0,\"action\":0,\"verdict\":1,\"container_id\":0,\"caps\":0,\"path_or_addr\":\"/bin/bash\",\"needed_perm\":\"allow.exec.allowed\"}\n\
+{\"pid\":2,\"tgid\":2,\"time_ns\":0,\"unit\":0,\"action\":0,\"verdict\":1,\"container_id\":0,\"caps\":0,\"path_or_addr\":\"1.2.3.4:443\",\"needed_perm\":\"allow.net.hosts\"}\n\
+{\"pid\":3,\"tgid\":3,\"time_ns\":0,\"unit\":0,\"action\":0,\"verdict\":1,\"container_id\":0,\"caps\":0,\"path_or_addr\":\"/tmp/foo\",\"needed_perm\":\"allow.fs.write_extra\"}\n",
+        )
+        .unwrap();
+
+        let out = dir.path().join("generated.toml");
+        exec_from_events(&events_path, &out, Mode::Enforce).unwrap();
+
+        let config = std::fs::read_to_string(&out).unwrap();
+        let policy = Policy::from_toml_str(&config).unwrap();
+        assert_eq!(policy.mode, Mode::Enforce);
+        assert!(policy.exec_allowed().any(|bin| bin == "/bin/bash"));
+        assert!(policy.net_hosts().any(|host| host == "1.2.3.4:443"));
+        assert!(
+            policy
+                .fs_write_paths()
+                .any(|path| path.to_string_lossy() == "/tmp/foo")
+        );
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,8 +1,10 @@
 pub mod build;
+pub mod doctor;
 mod events;
 pub mod init;
 pub mod report;
 pub mod run;
+pub mod setup;
 pub mod status;
 
 pub(crate) use events::{ReadEventsResult, read_recent_events};

--- a/crates/cli/src/commands/setup.rs
+++ b/crates/cli/src/commands/setup.rs
@@ -1,0 +1,135 @@
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use bpf_host::prebuilt::{PrebuiltObject, default_install_dir, default_search_directories};
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+pub(crate) struct SetupArgs {
+    pub(crate) bundle: Option<PathBuf>,
+    pub(crate) dest: Option<PathBuf>,
+    pub(crate) force: bool,
+}
+
+pub(crate) fn exec(args: SetupArgs) -> io::Result<()> {
+    if let Ok(obj) = PrebuiltObject::locate_default() {
+        if args.bundle.is_none() {
+            println!(
+                "bpf bundle already installed: version={} path={}",
+                obj.version(),
+                obj.path().display()
+            );
+            return Ok(());
+        }
+        if !args.force {
+            println!(
+                "bpf bundle already installed (version={} path={}); re-run with --force to reinstall",
+                obj.version(),
+                obj.path().display()
+            );
+            return Ok(());
+        }
+    }
+
+    let bundle = args.bundle.ok_or_else(|| {
+        let mut msg = String::from(
+            "missing --bundle <FILE>; download prebuilt.tar.gz and pass it here. searched:\n",
+        );
+        for dir in default_search_directories() {
+            msg.push_str("  - ");
+            msg.push_str(&dir.display().to_string());
+            msg.push('\n');
+        }
+        io::Error::new(io::ErrorKind::InvalidInput, msg)
+    })?;
+
+    let dest = match args.dest {
+        Some(dest) => dest,
+        None => default_install_dir().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "could not determine XDG data home (HOME/XDG_DATA_HOME missing); provide --dest",
+            )
+        })?,
+    };
+
+    install_bundle(&bundle, &dest, args.force)
+}
+
+fn install_bundle(bundle: &Path, dest: &Path, force: bool) -> io::Result<()> {
+    let parent = dest.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid destination {}", dest.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    if dest.exists() {
+        if !force {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "destination {} already exists; re-run with --force to replace",
+                    dest.display()
+                ),
+            ));
+        }
+        fs::remove_dir_all(dest)?;
+    }
+
+    let tmp = tempfile::Builder::new()
+        .prefix("cargo-warden-bpf-")
+        .tempdir_in(parent)?;
+
+    extract_tar_gz(bundle, tmp.path())?;
+
+    // Validate manifest + object checksum before installing.
+    let obj = PrebuiltObject::from_directory(tmp.path())?;
+
+    let extracted = tmp.into_path();
+    fs::rename(&extracted, dest)?;
+
+    println!(
+        "installed bpf bundle: version={} dest={} object={}",
+        obj.version(),
+        dest.display(),
+        obj.path().display()
+    );
+
+    Ok(())
+}
+
+fn extract_tar_gz(bundle: &Path, out_dir: &Path) -> io::Result<()> {
+    let file = fs::File::open(bundle)?;
+    let gz = GzDecoder::new(file);
+    let mut archive = Archive::new(gz);
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?;
+        ensure_safe_path(&path).map_err(|reason| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("bundle contains unsafe path {}: {reason}", path.display()),
+            )
+        })?;
+        entry.unpack_in(out_dir)?;
+    }
+
+    Ok(())
+}
+
+fn ensure_safe_path(path: &Path) -> Result<(), &'static str> {
+    if path.is_absolute() {
+        return Err("absolute path is not allowed");
+    }
+    if path
+        .components()
+        .any(|c| matches!(c, Component::ParentDir | Component::Prefix(_)))
+    {
+        return Err("path traversal is not allowed");
+    }
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -154,7 +154,20 @@ enum Commands {
         cmd: Vec<String>,
     },
     /// Initialize warden configuration.
-    Init,
+    Init {
+        /// Generate a policy from the default events log (warden-events.jsonl).
+        #[arg(long = "from-last-run", conflicts_with = "from_events")]
+        from_last_run: bool,
+        /// Generate a policy from a specific events log.
+        #[arg(long = "from-events", value_name = "FILE")]
+        from_events: Option<String>,
+        /// Mode written into the generated policy (defaults to enforce).
+        #[arg(long = "policy-mode", value_enum, default_value_t = CliMode::Enforce)]
+        policy_mode: CliMode,
+        /// Output path for the generated policy (defaults to warden.toml).
+        #[arg(long = "output", value_name = "FILE", default_value = "warden.toml")]
+        output: String,
+    },
     /// Show active policy and recent events.
     Status,
     /// Export events in text, JSON, or SARIF format.
@@ -166,6 +179,20 @@ enum Commands {
         #[arg(long = "output", value_name = "FILE")]
         output: Option<String>,
     },
+    /// Diagnose host prerequisites and configuration.
+    Doctor,
+    /// Install a prebuilt eBPF bundle into the default search path.
+    Setup {
+        /// Path to prebuilt.tar.gz bundle.
+        #[arg(long = "bundle", value_name = "FILE")]
+        bundle: Option<String>,
+        /// Destination directory (defaults to XDG data dir cargo-warden/bpf).
+        #[arg(long = "dest", value_name = "DIR")]
+        dest: Option<String>,
+        /// Replace an existing installation.
+        #[arg(long = "force")]
+        force: bool,
+    },
 }
 
 fn main() {
@@ -174,13 +201,6 @@ fn main() {
         args.remove(1);
     }
     let cli = Cli::parse_from(args);
-    if let Err(err) = privileges::enforce_least_privilege() {
-        eprintln!("privilege check failed: {err}");
-        eprintln!(
-            "Use a dedicated service user with CAP_SYS_ADMIN and, when available, CAP_BPF (see README for setup instructions)."
-        );
-        exit(1);
-    }
     let Cli {
         allow,
         policy,
@@ -188,6 +208,18 @@ fn main() {
         metrics_port,
         command,
     } = cli;
+
+    let needs_privileges = matches!(command, Commands::Build { .. } | Commands::Run { .. });
+    if needs_privileges {
+        if let Err(err) = privileges::enforce_least_privilege() {
+            eprintln!("privilege check failed: {err}");
+            eprintln!(
+                "Use a dedicated service user with CAP_SYS_ADMIN and, when available, CAP_BPF (see README for setup instructions)."
+            );
+            exit(1);
+        }
+    }
+
     let mode_override = mode.map(Mode::from);
     let agent_config = sandbox_runtime::AgentConfig {
         metrics_port,
@@ -210,8 +242,24 @@ fn main() {
                 exit(1);
             }
         }
-        Commands::Init => {
-            if let Err(e) = commands::init::exec() {
+        Commands::Init {
+            from_last_run,
+            from_events,
+            policy_mode,
+            output,
+        } => {
+            let out = std::path::Path::new(&output);
+            if from_last_run || from_events.is_some() {
+                let events = from_events.as_deref().unwrap_or("warden-events.jsonl");
+                if let Err(e) = commands::init::exec_from_events(
+                    std::path::Path::new(events),
+                    out,
+                    Mode::from(policy_mode),
+                ) {
+                    eprintln!("init failed: {e}");
+                    exit(1);
+                }
+            } else if let Err(e) = commands::init::exec_to(out) {
                 eprintln!("init failed: {e}");
                 exit(1);
             }
@@ -225,6 +273,27 @@ fn main() {
         Commands::Report { format, output } => {
             if let Err(e) = commands::report::exec(format.into(), output.as_deref()) {
                 eprintln!("report failed: {e}");
+                exit(1);
+            }
+        }
+        Commands::Doctor => {
+            if let Err(e) = commands::doctor::exec() {
+                eprintln!("doctor failed: {e}");
+                exit(1);
+            }
+        }
+        Commands::Setup {
+            bundle,
+            dest,
+            force,
+        } => {
+            let args = commands::setup::SetupArgs {
+                bundle: bundle.map(std::path::PathBuf::from),
+                dest: dest.map(std::path::PathBuf::from),
+                force,
+            };
+            if let Err(e) = commands::setup::exec(args) {
+                eprintln!("setup failed: {e}");
                 exit(1);
             }
         }
@@ -354,6 +423,6 @@ mod tests {
     #[test]
     fn parse_init_command() {
         let cli = Cli::parse_from(["cargo-warden", "init"]);
-        assert!(matches!(cli.command, Commands::Init));
+        assert!(matches!(cli.command, Commands::Init { .. }));
     }
 }

--- a/crates/cli/src/privileges.rs
+++ b/crates/cli/src/privileges.rs
@@ -148,6 +148,30 @@ pub(crate) fn enforce_least_privilege() -> Result<(), PrivilegeError> {
     validate_capabilities(effective_caps)
 }
 
+pub(crate) fn is_privilege_check_skipped() -> bool {
+    std::env::var_os(SKIP_ENV).is_some()
+}
+
+pub(crate) fn is_isolated() -> Result<bool, PrivilegeError> {
+    detect_isolation()
+}
+
+pub(crate) fn effective_capabilities() -> Result<u64, PrivilegeError> {
+    read_effective_capabilities()
+}
+
+pub(crate) fn required_cap_mask() -> u64 {
+    REQUIRED_CAP_MASK
+}
+
+pub(crate) fn allowed_cap_mask() -> u64 {
+    ALLOWED_CAP_MASK
+}
+
+pub(crate) fn describe_cap_mask(mask: u64) -> String {
+    describe_capabilities(mask)
+}
+
 fn validate_capabilities(effective_caps: u64) -> Result<(), PrivilegeError> {
     if effective_caps & REQUIRED_CAP_MASK != REQUIRED_CAP_MASK {
         let missing = REQUIRED_CAP_MASK & !effective_caps;


### PR DESCRIPTION
## Summary
- add `cargo warden doctor` to report host prerequisites and privilege/isolation status without requiring CAP checks
- add `cargo warden setup --bundle <prebuilt.tar.gz>` with safe tar extraction, bundle validation via `PrebuiltObject::from_directory`, and atomic install semantics
- extend `cargo warden init` with `--from-last-run` / `--from-events`, `--policy-mode`, and `--output` to generate a starter policy from denied events
- keep least-privilege enforcement for `build` and `run` only; allow non-invasive commands (`doctor`, `setup`, `init`, `status`, `report`) without upfront privilege gating
- document the new first-run/second-run workflow in README

## Verification
- `cargo fmt`
- `cargo test -p cargo-warden` *(fails on this Windows host due to `libseccomp` unix-only import)*
- `cargo test -p warden-bpf-host` *(1 failing test on this Windows host: `prebuilt::tests::loads_and_validates_object` manifest path escaping)*